### PR TITLE
Fix version history marking wrong version as current after restore

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -409,12 +409,18 @@ manage_project_server <- function(id, board, ...) {
             )
           }
 
+          active_version <- parseQueryString(coal(prev_query(), ""))$version
+
           items <- lapply(
             seq_len(min(nrow(versions), 4)),
             function(i) {
               v <- versions[i, ]
               time_ago <- format_time_ago(v$created)
-              is_current <- i == 1
+              is_current <- if (is.null(active_version)) {
+                i == 1L
+              } else {
+                identical(v$version, active_version)
+              }
 
               tags$div(
                 class = paste(
@@ -1049,12 +1055,18 @@ show_workflows_modal <- function(workflows, backend, session) {
 
 show_versions_modal <- function(id, versions, session, backend) {
 
+  active_version <- getQueryString(session)$version
+
   rows <- lapply(
     seq_len(nrow(versions)),
     function(i) {
       v <- versions[i, ]
       time_ago <- format_time_ago(v$created)
-      is_current <- i == 1
+      is_current <- if (is.null(active_version)) {
+        i == 1L
+      } else {
+        identical(v$version, active_version)
+      }
 
       tags$tr(
         class = "blockr-workflow-row",

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -163,6 +163,54 @@ test_that("load_version restores specific version", {
   )
 })
 
+test_that("version history marks loaded version as current (#19)", {
+
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  test_board <- new_board(
+    blocks = c(a = new_dataset_block("iris"))
+  )
+
+  testServer(
+    manage_project_server,
+    {
+      session$setInputs(save_btn = 1)
+      Sys.sleep(1)
+      session$setInputs(save_btn = 2)
+    },
+    args = list(
+      board = reactiveValues(board = test_board, board_id = "hist-current")
+    )
+  )
+
+  versions <- pins::pin_versions(backend, "hist-current")
+  versions <- versions[order(versions$created, decreasing = TRUE), ]
+  newer_version <- versions$version[1]
+  older_version <- versions$version[2]
+
+  testServer(
+    manage_project_server,
+    {
+      session$setInputs(
+        load_version = list(
+          name = "hist-current",
+          version = older_version,
+          user = ""
+        )
+      )
+
+      html <- output$version_history
+
+      expect_true(any(grepl(newer_version, html, fixed = TRUE)))
+      expect_false(any(grepl(older_version, html, fixed = TRUE)))
+    },
+    args = list(
+      board = reactiveValues(board = test_board, board_id = "hist-current")
+    )
+  )
+})
+
 test_that("safe_restore_board returns TRUE on success", {
   local_mocked_bindings(
     restore_board = function(...) invisible(NULL)


### PR DESCRIPTION
Both the sidebar version list and the "View all versions" modal determined which version is "(Current)" using `is_current <- i == 1` — always marking the newest version as current regardless of which one was actually loaded.

After restoring an older version the newest version was still marked current, so clicking any other version in the list targeted the wrong entry (the reporter's "second version becomes unrestorable" scenario).

The fix reads the active version from the URL query string (`?version=<id>`) and matches it against each version row. When no version parameter is present (e.g. right after saving), the newest version is still treated as current — preserving existing behavior.

Closes #19