### PR TITLE
Register preload callback to fix double reload on refresh

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,4 @@ Suggests:
     withr
 Config/testthat/edition: 3
 Remotes:
-    BristolMyersSquibb/blockr.core
+    BristolMyersSquibb/blockr.core@153-double-load

--- a/R/project.R
+++ b/R/project.R
@@ -12,5 +12,40 @@
 manage_project <- function(server = manage_project_server,
                            ui = manage_project_ui) {
 
+  register_board_preload(session_preload)
+
   preserve_board(server, ui)
+}
+
+session_preload <- function(query, req) {
+
+  if (is.null(query$board_name)) {
+    return(NULL)
+  }
+
+  backend <- tryCatch(get_session_backend(), error = function(e) NULL)
+
+  if (is.null(backend)) {
+    return(NULL)
+  }
+
+  id <- rack_id_from_input(
+    list(
+      name = query$board_name,
+      user = query$user,
+      version = query$version
+    ),
+    backend
+  )
+
+  board_ser <- tryCatch(rack_load(id, backend), error = function(e) NULL)
+
+  if (is.null(board_ser)) {
+    return(NULL)
+  }
+
+  list(
+    board = blockr_deser(board_ser),
+    meta = list(url = board_query_string(id, backend))
+  )
 }


### PR DESCRIPTION
Depends on BristolMyersSquibb/blockr.core#153.

On browser refresh of a saved board URL, the app performed two full page loads because `board$reload_meta` was NULL on fresh loads, causing the URL observer to trigger the full `restore_board()` → `session$reload()` cycle.

`manage_project()` now registers a `session_preload` callback via `register_board_preload()` that loads the board from the pins backend during the HTTP request phase. The board is available in `serve_obj` before `board_server()` initializes, so `prev_query` matches the URL and the URL observer returns early — no redundant reload.

The preload is best-effort: if the backend isn't reachable or another reload is already in flight, it silently falls back to the existing double-reload behavior.

Closes #41