### PR TITLE
Put URL parameter sync behind feature flag

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -28,8 +28,8 @@ manage_project_server <- function(id, board, ...) {
 
       prev_query <- reactiveVal(isolate(board$reload_meta$url))
 
-      log_info(
-        "[RELOAD-DEBUG] manage_project_server init | ",
+      log_debug(
+        "reload: manage_project_server | init | ",
         "session: {substr(session$token, 1, 8)} | ",
         "use_url: {use_url} | ",
         "prev_query: {coal(isolate(board$reload_meta$url), '(null)')}"
@@ -63,16 +63,16 @@ manage_project_server <- function(id, board, ...) {
       observeEvent(
         session$clientData$url_search,
         {
-          log_info(
-            "[RELOAD-DEBUG] URL observer fired | ",
+          log_debug(
+            "reload: url_search | fired | ",
             "session: {substr(session$token, 1, 8)} | ",
             "use_url: {use_url} | ",
             "url_search: {coal(session$clientData$url_search, '(empty)')}"
           )
 
           if (!use_url) {
-            log_info(
-              "[RELOAD-DEBUG] URL observer: use_url=FALSE, returning | ",
+            log_debug(
+              "reload: url_search | use_url=FALSE, returning | ",
               "session: {substr(session$token, 1, 8)}"
             )
             return()
@@ -81,8 +81,8 @@ manage_project_server <- function(id, board, ...) {
           query <- getQueryString(session)
 
           if (is.null(query$board_name)) {
-            log_info(
-              "[RELOAD-DEBUG] URL observer: no board_name, returning | ",
+            log_debug(
+              "reload: url_search | no board_name, returning | ",
               "session: {substr(session$token, 1, 8)}"
             )
             return()
@@ -104,8 +104,8 @@ manage_project_server <- function(id, board, ...) {
           # the post-session$reload() case (prev_query is initialized from the
           # pkg-level reload state that persists across session reloads).
           if (identical(new_url, prev_query())) {
-            log_info(
-              "[RELOAD-DEBUG] URL observer: guard MATCHED, skipping | ",
+            log_debug(
+              "reload: url_search | guard MATCHED, skipping | ",
               "session: {substr(session$token, 1, 8)} | ",
               "url: {new_url}"
             )
@@ -113,8 +113,8 @@ manage_project_server <- function(id, board, ...) {
             return()
           }
 
-          log_info(
-            "[RELOAD-DEBUG] URL observer: guard MISSED, will restore | ",
+          log_debug(
+            "reload: url_search | guard MISSED, will restore | ",
             "session: {substr(session$token, 1, 8)} | ",
             "new_url: {new_url} | ",
             "prev_query: {coal(prev_query(), '(null)')}"
@@ -135,8 +135,8 @@ manage_project_server <- function(id, board, ...) {
           )
 
           if (ok) {
-            log_info(
-              "[RELOAD-DEBUG] URL observer: restore OK, will reload | ",
+            log_debug(
+              "reload: url_search | restore OK, will reload | ",
               "session: {substr(session$token, 1, 8)}"
             )
             set_board_option_value("board_name", query$board_name, session)
@@ -264,8 +264,8 @@ manage_project_server <- function(id, board, ...) {
       observeEvent(
         input$load_workflow,
         {
-          log_info(
-            "[RELOAD-DEBUG] load_workflow clicked | ",
+          log_debug(
+            "reload: load_workflow | clicked | ",
             "session: {substr(session$token, 1, 8)} | ",
             "name: {coal(input$load_workflow$name, '?')}"
           )
@@ -290,8 +290,8 @@ manage_project_server <- function(id, board, ...) {
           )
 
           if (ok) {
-            log_info(
-              "[RELOAD-DEBUG] load_workflow: restore OK, will reload | ",
+            log_debug(
+              "reload: load_workflow | restore OK, will reload | ",
               "session: {substr(session$token, 1, 8)} | ",
               "url: {new_url} | ",
               "use_url: {use_url}"
@@ -526,8 +526,8 @@ manage_project_server <- function(id, board, ...) {
         {
           req(input$load_version$name, input$load_version$version)
 
-          log_info(
-            "[RELOAD-DEBUG] load_version clicked | ",
+          log_debug(
+            "reload: load_version | clicked | ",
             "session: {substr(session$token, 1, 8)} | ",
             "name: {input$load_version$name} | ",
             "version: {input$load_version$version}"
@@ -553,8 +553,8 @@ manage_project_server <- function(id, board, ...) {
           )
 
           if (ok) {
-            log_info(
-              "[RELOAD-DEBUG] load_version: restore OK, will reload | ",
+            log_debug(
+              "reload: load_version | restore OK, will reload | ",
               "session: {substr(session$token, 1, 8)} | ",
               "url: {new_url} | ",
               "use_url: {use_url}"

--- a/R/server.R
+++ b/R/server.R
@@ -28,6 +28,13 @@ manage_project_server <- function(id, board, ...) {
 
       prev_query <- reactiveVal(isolate(board$reload_meta$url))
 
+      log_info(
+        "[RELOAD-DEBUG] manage_project_server init | ",
+        "session: {substr(session$token, 1, 8)} | ",
+        "use_url: {use_url} | ",
+        "prev_query: {coal(isolate(board$reload_meta$url), '(null)')}"
+      )
+
       prev_board_name <- reactiveVal(NULL)
 
       observeEvent(
@@ -56,11 +63,28 @@ manage_project_server <- function(id, board, ...) {
       observeEvent(
         session$clientData$url_search,
         {
-          if (!use_url) return()
+          log_info(
+            "[RELOAD-DEBUG] URL observer fired | ",
+            "session: {substr(session$token, 1, 8)} | ",
+            "use_url: {use_url} | ",
+            "url_search: {coal(session$clientData$url_search, '(empty)')}"
+          )
+
+          if (!use_url) {
+            log_info(
+              "[RELOAD-DEBUG] URL observer: use_url=FALSE, returning | ",
+              "session: {substr(session$token, 1, 8)}"
+            )
+            return()
+          }
 
           query <- getQueryString(session)
 
           if (is.null(query$board_name)) {
+            log_info(
+              "[RELOAD-DEBUG] URL observer: no board_name, returning | ",
+              "session: {substr(session$token, 1, 8)}"
+            )
             return()
           }
 
@@ -80,9 +104,21 @@ manage_project_server <- function(id, board, ...) {
           # the post-session$reload() case (prev_query is initialized from the
           # pkg-level reload state that persists across session reloads).
           if (identical(new_url, prev_query())) {
+            log_info(
+              "[RELOAD-DEBUG] URL observer: guard MATCHED, skipping | ",
+              "session: {substr(session$token, 1, 8)} | ",
+              "url: {new_url}"
+            )
             set_board_option_value("board_name", query$board_name, session)
             return()
           }
+
+          log_info(
+            "[RELOAD-DEBUG] URL observer: guard MISSED, will restore | ",
+            "session: {substr(session$token, 1, 8)} | ",
+            "new_url: {new_url} | ",
+            "prev_query: {coal(prev_query(), '(null)')}"
+          )
 
           board_ser <- tryCatch(
             rack_load(id, backend),
@@ -99,6 +135,10 @@ manage_project_server <- function(id, board, ...) {
           )
 
           if (ok) {
+            log_info(
+              "[RELOAD-DEBUG] URL observer: restore OK, will reload | ",
+              "session: {substr(session$token, 1, 8)}"
+            )
             set_board_option_value("board_name", query$board_name, session)
             updateQueryString(new_url, mode = "replace", session = session)
           }
@@ -224,6 +264,12 @@ manage_project_server <- function(id, board, ...) {
       observeEvent(
         input$load_workflow,
         {
+          log_info(
+            "[RELOAD-DEBUG] load_workflow clicked | ",
+            "session: {substr(session$token, 1, 8)} | ",
+            "name: {coal(input$load_workflow$name, '?')}"
+          )
+
           id <- rack_id_from_input(input$load_workflow)
 
           board_ser <- tryCatch(
@@ -243,10 +289,18 @@ manage_project_server <- function(id, board, ...) {
             meta = list(url = new_url), session = session
           )
 
-          if (ok && use_url) {
-            updateQueryString(
-              new_url, mode = "replace", session = session
+          if (ok) {
+            log_info(
+              "[RELOAD-DEBUG] load_workflow: restore OK, will reload | ",
+              "session: {substr(session$token, 1, 8)} | ",
+              "url: {new_url} | ",
+              "use_url: {use_url}"
             )
+            if (use_url) {
+              updateQueryString(
+                new_url, mode = "replace", session = session
+              )
+            }
           }
         }
       )
@@ -472,6 +526,13 @@ manage_project_server <- function(id, board, ...) {
         {
           req(input$load_version$name, input$load_version$version)
 
+          log_info(
+            "[RELOAD-DEBUG] load_version clicked | ",
+            "session: {substr(session$token, 1, 8)} | ",
+            "name: {input$load_version$name} | ",
+            "version: {input$load_version$version}"
+          )
+
           id <- rack_id_from_input(input$load_version)
 
           board_ser <- tryCatch(
@@ -491,10 +552,18 @@ manage_project_server <- function(id, board, ...) {
             meta = list(url = new_url), session = session
           )
 
-          if (ok && use_url) {
-            updateQueryString(
-              new_url, mode = "replace", session = session
+          if (ok) {
+            log_info(
+              "[RELOAD-DEBUG] load_version: restore OK, will reload | ",
+              "session: {substr(session$token, 1, 8)} | ",
+              "url: {new_url} | ",
+              "use_url: {use_url}"
             )
+            if (use_url) {
+              updateQueryString(
+                new_url, mode = "replace", session = session
+              )
+            }
           }
         }
       )

--- a/R/server.R
+++ b/R/server.R
@@ -449,7 +449,7 @@ manage_project_server <- function(id, board, ...) {
                 onclick = if (!is_current) {
                   shiny_input_obj_js(
                     session$ns("load_version"),
-                    name = name,
+                    name = id$name,
                     user = coal(id$user, ""),
                     version = v$version
                   )

--- a/R/server.R
+++ b/R/server.R
@@ -24,6 +24,8 @@ manage_project_server <- function(id, board, ...) {
         )
       )
 
+      use_url <- url_params_enabled()
+
       prev_query <- reactiveVal(isolate(board$reload_meta$url))
 
       prev_board_name <- reactiveVal(NULL)
@@ -54,6 +56,8 @@ manage_project_server <- function(id, board, ...) {
       observeEvent(
         session$clientData$url_search,
         {
+          if (!use_url) return()
+
           query <- getQueryString(session)
 
           if (is.null(query$board_name)) {
@@ -132,7 +136,12 @@ manage_project_server <- function(id, board, ...) {
               backend
             )
             prev_query(new_url)
-            updateQueryString(new_url, mode = "replace", session = session)
+
+            if (use_url) {
+              updateQueryString(
+                new_url, mode = "replace", session = session
+              )
+            }
           }
         }
       )
@@ -146,7 +155,9 @@ manage_project_server <- function(id, board, ...) {
           new <- reset_board_name(new, id_to_sentence_case(new_id))
           restore_result(new)
 
-          updateQueryString("?", mode = "replace", session = session)
+          if (use_url) {
+            updateQueryString("?", mode = "replace", session = session)
+          }
         }
       )
 
@@ -186,13 +197,17 @@ manage_project_server <- function(id, board, ...) {
                     ),
                     tags$div(class = "blockr-workflow-meta", wf_time)
                   ),
-                  tags$a(
-                    class = "blockr-open-newtab",
-                    href = board_query_string(wf, backend),
-                    target = "_blank",
-                    onclick = "event.stopPropagation();",
-                    bsicons::bs_icon("box-arrow-up-right", size = "0.75em")
-                  )
+                  if (use_url) {
+                    tags$a(
+                      class = "blockr-open-newtab",
+                      href = board_query_string(wf, backend),
+                      target = "_blank",
+                      onclick = "event.stopPropagation();",
+                      bsicons::bs_icon(
+                        "box-arrow-up-right", size = "0.75em"
+                      )
+                    )
+                  }
                 )
               }
             )
@@ -228,8 +243,10 @@ manage_project_server <- function(id, board, ...) {
             meta = list(url = new_url), session = session
           )
 
-          if (ok) {
-            updateQueryString(new_url, mode = "replace", session = session)
+          if (ok && use_url) {
+            updateQueryString(
+              new_url, mode = "replace", session = session
+            )
           }
         }
       )
@@ -248,7 +265,7 @@ manage_project_server <- function(id, board, ...) {
             return()
           }
 
-          show_workflows_modal(workflows, backend, session)
+          show_workflows_modal(workflows, backend, session, use_url)
         }
       )
 
@@ -474,8 +491,10 @@ manage_project_server <- function(id, board, ...) {
             meta = list(url = new_url), session = session
           )
 
-          if (ok) {
-            updateQueryString(new_url, mode = "replace", session = session)
+          if (ok && use_url) {
+            updateQueryString(
+              new_url, mode = "replace", session = session
+            )
           }
         }
       )
@@ -505,7 +524,7 @@ manage_project_server <- function(id, board, ...) {
             return()
           }
 
-          show_versions_modal(id, versions, session, backend)
+          show_versions_modal(id, versions, session, backend, use_url)
         }
       )
 
@@ -884,7 +903,7 @@ hide_modal_js <- function(modal_id) {
   )
 }
 
-show_workflows_modal <- function(workflows, backend, session) {
+show_workflows_modal <- function(workflows, backend, session, use_url) {
 
   rows <- lapply(
     seq_along(workflows),
@@ -923,15 +942,17 @@ show_workflows_modal <- function(workflows, backend, session) {
               ),
               "Load"
             ),
-            tags$a(
-              class = "btn btn-sm btn-outline-secondary",
-              href = board_query_string(wf, backend),
-              target = "_blank",
-              bsicons::bs_icon(
-                "box-arrow-up-right",
-                size = "0.85em"
+            if (use_url) {
+              tags$a(
+                class = "btn btn-sm btn-outline-secondary",
+                href = board_query_string(wf, backend),
+                target = "_blank",
+                bsicons::bs_icon(
+                  "box-arrow-up-right",
+                  size = "0.85em"
+                )
               )
-            ),
+            },
             tags$button(
               class = "btn btn-sm btn-outline-primary blockr-wf-row-btn",
               title = "Download",
@@ -1055,7 +1076,7 @@ show_workflows_modal <- function(workflows, backend, session) {
   )
 }
 
-show_versions_modal <- function(id, versions, session, backend) {
+show_versions_modal <- function(id, versions, session, backend, use_url) {
 
   active_version <- getQueryString(session)$version
 
@@ -1110,22 +1131,24 @@ show_versions_modal <- function(id, versions, session, backend) {
                 "Load"
               )
             },
-            tags$a(
-              class = "btn btn-sm btn-outline-secondary",
-              href = board_query_string(
-                list(
-                  name = id$name,
-                  user = id$user,
-                  version = v$version
+            if (use_url) {
+              tags$a(
+                class = "btn btn-sm btn-outline-secondary",
+                href = board_query_string(
+                  list(
+                    name = id$name,
+                    user = id$user,
+                    version = v$version
+                  ),
+                  backend
                 ),
-                backend
-              ),
-              target = "_blank",
-              bsicons::bs_icon(
-                "box-arrow-up-right",
-                size = "0.85em"
+                target = "_blank",
+                bsicons::bs_icon(
+                  "box-arrow-up-right",
+                  size = "0.85em"
+                )
               )
-            ),
+            },
             tags$button(
               class = paste(
                 "btn btn-sm btn-outline-primary blockr-wf-row-btn"

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,7 @@
+url_params_enabled <- function() {
+  isTRUE(blockr_option("session_url_params", FALSE))
+}
+
 get_session_backend <- function() {
 
   val <- blockr_option("session_mgmt_backend", pins::board_local)


### PR DESCRIPTION
URL param synchronization is causing chained reload sequences (2-6+) on Connect. This gates all browser URL bar interactions behind an opt-in option:

```r
options(blockr.session_url_params = TRUE)
```

When disabled (the default), the URL observer, `updateQueryString()` calls, and "open in new tab" links are all skipped. Internal `prev_query` state tracking is preserved so version history current-version highlighting continues to work.

Closes #43