### PR TITLE
Change browser reload to return to initial state

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -27,6 +27,7 @@ manage_project_server <- function(id, board, ...) {
       use_url <- url_params_enabled()
 
       active_version <- reactiveVal(NULL)
+      last_url <- reactiveVal(NULL)
 
       log_debug(
         "reload: manage_project_server | init | ",
@@ -79,12 +80,70 @@ manage_project_server <- function(id, board, ...) {
 
           query <- getQueryString(session)
 
-          if (!is.null(query$board_name)) {
+          if (is.null(query$board_name)) {
             log_debug(
-              "reload: url_search | clearing params | ",
+              "reload: url_search | no board_name, returning | ",
               "session: {substr(session$token, 1, 8)}"
             )
-            updateQueryString("?", mode = "replace", session = session)
+            return()
+          }
+
+          id <- rack_id_from_input(
+            list(
+              name = query$board_name,
+              user = query$user,
+              version = query$version
+            ),
+            backend
+          )
+
+          new_url <- board_query_string(id, backend)
+
+          if (identical(new_url, last_url())) {
+            log_debug(
+              "reload: url_search | guard MATCHED, skipping | ",
+              "session: {substr(session$token, 1, 8)} | ",
+              "url: {new_url}"
+            )
+            return()
+          }
+
+          log_debug(
+            "reload: url_search | guard MISSED, will restore | ",
+            "session: {substr(session$token, 1, 8)} | ",
+            "new_url: {new_url} | ",
+            "last_url: {coal(last_url(), '(null)')}"
+          )
+
+          board_ser <- tryCatch(
+            rack_load(id, backend),
+            error = cnd_to_notif(type = "error")
+          )
+
+          if (is.null(board_ser)) return()
+
+          if (not_null(query$version)) {
+            active_version(query$version)
+          }
+
+          last_url(new_url)
+
+          ok <- safe_restore_board(
+            board$board, board_ser, restore_result,
+            session = session
+          )
+
+          if (ok) {
+            log_debug(
+              "reload: url_search | restore OK, will reload | ",
+              "session: {substr(session$token, 1, 8)}"
+            )
+            set_board_option_value(
+              "board_name", query$board_name, session
+            )
+            updateQueryString(
+              new_url, mode = "replace", session = session
+            )
           }
         }
       )
@@ -122,6 +181,8 @@ manage_project_server <- function(id, board, ...) {
               backend
             )
 
+            last_url(new_url)
+
             if (use_url) {
               updateQueryString(
                 new_url, mode = "replace", session = session
@@ -139,6 +200,8 @@ manage_project_server <- function(id, board, ...) {
           attr(new, "id") <- new_id
           new <- reset_board_name(new, id_to_sentence_case(new_id))
           restore_result(new)
+
+          last_url(NULL)
 
           if (use_url) {
             updateQueryString("?", mode = "replace", session = session)
@@ -229,6 +292,7 @@ manage_project_server <- function(id, board, ...) {
           active_version(NULL)
 
           new_url <- board_query_string(id, backend)
+          last_url(new_url)
 
           ok <- safe_restore_board(
             board$board, board_ser, restore_result,
@@ -493,6 +557,7 @@ manage_project_server <- function(id, board, ...) {
           active_version(input$load_version$version)
 
           new_url <- board_query_string(id, backend)
+          last_url(new_url)
 
           ok <- safe_restore_board(
             board$board, board_ser, restore_result,

--- a/R/server.R
+++ b/R/server.R
@@ -27,7 +27,6 @@ manage_project_server <- function(id, board, ...) {
       use_url <- url_params_enabled()
 
       active_version <- reactiveVal(NULL)
-      last_url <- reactiveVal(NULL)
 
       log_debug(
         "reload: manage_project_server | init | ",
@@ -60,11 +59,15 @@ manage_project_server <- function(id, board, ...) {
         }
       )
 
+      session$sendCustomMessage(
+        "blockr-get-nav-type", session$ns("nav_type")
+      )
+
       observeEvent(
-        session$clientData$url_search,
+        input$nav_type,
         {
           log_debug(
-            "reload: url_search | fired | ",
+            "reload: nav_type | fired | ",
             "session: {substr(session$token, 1, 8)} | ",
             "use_url: {use_url} | ",
             "url_search: {coal(session$clientData$url_search, '(empty)')}"
@@ -72,9 +75,18 @@ manage_project_server <- function(id, board, ...) {
 
           if (!use_url) {
             log_debug(
-              "reload: url_search | use_url=FALSE, returning | ",
+              "reload: nav_type | use_url=FALSE, returning | ",
               "session: {substr(session$token, 1, 8)}"
             )
+            return()
+          }
+
+          if (identical(input$nav_type, "reload")) {
+            log_debug(
+              "reload: nav_type | clearing params (reload) | ",
+              "session: {substr(session$token, 1, 8)}"
+            )
+            updateQueryString("?", mode = "replace", session = session)
             return()
           }
 
@@ -82,7 +94,7 @@ manage_project_server <- function(id, board, ...) {
 
           if (is.null(query$board_name)) {
             log_debug(
-              "reload: url_search | no board_name, returning | ",
+              "reload: nav_type | no board_name, returning | ",
               "session: {substr(session$token, 1, 8)}"
             )
             return()
@@ -97,24 +109,6 @@ manage_project_server <- function(id, board, ...) {
             backend
           )
 
-          new_url <- board_query_string(id, backend)
-
-          if (identical(new_url, last_url())) {
-            log_debug(
-              "reload: url_search | guard MATCHED, skipping | ",
-              "session: {substr(session$token, 1, 8)} | ",
-              "url: {new_url}"
-            )
-            return()
-          }
-
-          log_debug(
-            "reload: url_search | guard MISSED, will restore | ",
-            "session: {substr(session$token, 1, 8)} | ",
-            "new_url: {new_url} | ",
-            "last_url: {coal(last_url(), '(null)')}"
-          )
-
           board_ser <- tryCatch(
             rack_load(id, backend),
             error = cnd_to_notif(type = "error")
@@ -126,8 +120,6 @@ manage_project_server <- function(id, board, ...) {
             active_version(query$version)
           }
 
-          last_url(new_url)
-
           ok <- safe_restore_board(
             board$board, board_ser, restore_result,
             session = session
@@ -135,14 +127,15 @@ manage_project_server <- function(id, board, ...) {
 
           if (ok) {
             log_debug(
-              "reload: url_search | restore OK, will reload | ",
+              "reload: nav_type | restore OK, will reload | ",
               "session: {substr(session$token, 1, 8)}"
             )
             set_board_option_value(
               "board_name", query$board_name, session
             )
             updateQueryString(
-              new_url, mode = "replace", session = session
+              board_query_string(id, backend),
+              mode = "replace", session = session
             )
           }
         }
@@ -181,7 +174,6 @@ manage_project_server <- function(id, board, ...) {
               backend
             )
 
-            last_url(new_url)
 
             if (use_url) {
               updateQueryString(
@@ -200,8 +192,6 @@ manage_project_server <- function(id, board, ...) {
           attr(new, "id") <- new_id
           new <- reset_board_name(new, id_to_sentence_case(new_id))
           restore_result(new)
-
-          last_url(NULL)
 
           if (use_url) {
             updateQueryString("?", mode = "replace", session = session)
@@ -292,7 +282,6 @@ manage_project_server <- function(id, board, ...) {
           active_version(NULL)
 
           new_url <- board_query_string(id, backend)
-          last_url(new_url)
 
           ok <- safe_restore_board(
             board$board, board_ser, restore_result,
@@ -557,7 +546,6 @@ manage_project_server <- function(id, board, ...) {
           active_version(input$load_version$version)
 
           new_url <- board_query_string(id, backend)
-          last_url(new_url)
 
           ok <- safe_restore_board(
             board$board, board_ser, restore_result,

--- a/R/server.R
+++ b/R/server.R
@@ -26,13 +26,12 @@ manage_project_server <- function(id, board, ...) {
 
       use_url <- url_params_enabled()
 
-      prev_query <- reactiveVal(isolate(board$reload_meta$url))
+      active_version <- reactiveVal(NULL)
 
       log_debug(
         "reload: manage_project_server | init | ",
         "session: {substr(session$token, 1, 8)} | ",
-        "use_url: {use_url} | ",
-        "prev_query: {coal(isolate(board$reload_meta$url), '(null)')}"
+        "use_url: {use_url}"
       )
 
       prev_board_name <- reactiveVal(NULL)
@@ -80,67 +79,12 @@ manage_project_server <- function(id, board, ...) {
 
           query <- getQueryString(session)
 
-          if (is.null(query$board_name)) {
+          if (!is.null(query$board_name)) {
             log_debug(
-              "reload: url_search | no board_name, returning | ",
+              "reload: url_search | clearing params | ",
               "session: {substr(session$token, 1, 8)}"
             )
-            return()
-          }
-
-          id <- rack_id_from_input(
-            list(
-              name = query$board_name,
-              user = query$user,
-              version = query$version
-            ),
-            backend
-          )
-
-          new_url <- board_query_string(id, backend)
-
-          # Skip if the URL matches what we last set ourselves. This prevents
-          # re-triggering after our own updateQueryString calls and also handles
-          # the post-session$reload() case (prev_query is initialized from the
-          # pkg-level reload state that persists across session reloads).
-          if (identical(new_url, prev_query())) {
-            log_debug(
-              "reload: url_search | guard MATCHED, skipping | ",
-              "session: {substr(session$token, 1, 8)} | ",
-              "url: {new_url}"
-            )
-            set_board_option_value("board_name", query$board_name, session)
-            return()
-          }
-
-          log_debug(
-            "reload: url_search | guard MISSED, will restore | ",
-            "session: {substr(session$token, 1, 8)} | ",
-            "new_url: {new_url} | ",
-            "prev_query: {coal(prev_query(), '(null)')}"
-          )
-
-          board_ser <- tryCatch(
-            rack_load(id, backend),
-            error = cnd_to_notif(type = "error")
-          )
-
-          if (is.null(board_ser)) return()
-
-          prev_query(new_url)
-
-          ok <- safe_restore_board(
-            board$board, board_ser, restore_result,
-            meta = list(url = new_url), session = session
-          )
-
-          if (ok) {
-            log_debug(
-              "reload: url_search | restore OK, will reload | ",
-              "session: {substr(session$token, 1, 8)}"
-            )
-            set_board_option_value("board_name", query$board_name, session)
-            updateQueryString(new_url, mode = "replace", session = session)
+            updateQueryString("?", mode = "replace", session = session)
           }
         }
       )
@@ -171,11 +115,12 @@ manage_project_server <- function(id, board, ...) {
             save_status("Just now")
             refresh_trigger(refresh_trigger() + 1)
 
+            active_version(NULL)
+
             new_url <- board_query_string(
               rack_id_for_board(board_name(), backend),
               backend
             )
-            prev_query(new_url)
 
             if (use_url) {
               updateQueryString(
@@ -281,12 +226,13 @@ manage_project_server <- function(id, board, ...) {
             return()
           }
 
+          active_version(NULL)
+
           new_url <- board_query_string(id, backend)
-          prev_query(new_url)
 
           ok <- safe_restore_board(
             board$board, board_ser, restore_result,
-            meta = list(url = new_url), session = session
+            session = session
           )
 
           if (ok) {
@@ -482,17 +428,17 @@ manage_project_server <- function(id, board, ...) {
             )
           }
 
-          active_version <- parseQueryString(coal(prev_query(), ""))$version
+          cur_version <- active_version()
 
           items <- lapply(
             seq_len(min(nrow(versions), 4)),
             function(i) {
               v <- versions[i, ]
               time_ago <- format_time_ago(v$created)
-              is_current <- if (is.null(active_version)) {
+              is_current <- if (is.null(cur_version)) {
                 i == 1L
               } else {
-                identical(v$version, active_version)
+                identical(v$version, cur_version)
               }
 
               tags$div(
@@ -544,12 +490,13 @@ manage_project_server <- function(id, board, ...) {
             return()
           }
 
+          active_version(input$load_version$version)
+
           new_url <- board_query_string(id, backend)
-          prev_query(new_url)
 
           ok <- safe_restore_board(
             board$board, board_ser, restore_result,
-            meta = list(url = new_url), session = session
+            session = session
           )
 
           if (ok) {
@@ -593,7 +540,9 @@ manage_project_server <- function(id, board, ...) {
             return()
           }
 
-          show_versions_modal(id, versions, session, backend, use_url)
+          show_versions_modal(
+            id, versions, session, backend, use_url, active_version()
+          )
         }
       )
 
@@ -1145,9 +1094,8 @@ show_workflows_modal <- function(workflows, backend, session, use_url) {
   )
 }
 
-show_versions_modal <- function(id, versions, session, backend, use_url) {
-
-  active_version <- getQueryString(session)$version
+show_versions_modal <- function(id, versions, session, backend, use_url,
+                                active_version = NULL) {
 
   rows <- lapply(
     seq_len(nrow(versions)),

--- a/R/utils.R
+++ b/R/utils.R
@@ -146,7 +146,7 @@ normalize_js_input <- function(x) {
 }
 
 safe_restore_board <- function(board, board_ser, restore_result,
-                               meta = NULL, session) {
+                               meta = list(), session) {
   tryCatch(
     {
       restore_board(

--- a/inst/assets/js/project-navbar.js
+++ b/inst/assets/js/project-navbar.js
@@ -1,5 +1,12 @@
 // Project navbar JavaScript handlers
 
+(function() {
+  var nav = performance.getEntriesByType('navigation');
+  if (nav.length > 0 && nav[0].type === 'reload') {
+    history.replaceState({}, '', window.location.pathname);
+  }
+})();
+
 // Update navbar title from server
 Shiny.addCustomMessageHandler('blockr-update-navbar-title', function(title) {
   document.querySelectorAll('.blockr-navbar-title').forEach(function(el) {

--- a/inst/assets/js/project-navbar.js
+++ b/inst/assets/js/project-navbar.js
@@ -1,11 +1,10 @@
 // Project navbar JavaScript handlers
 
-(function() {
+Shiny.addCustomMessageHandler('blockr-get-nav-type', function(inputId) {
   var nav = performance.getEntriesByType('navigation');
-  if (nav.length > 0 && nav[0].type === 'reload') {
-    history.replaceState({}, '', window.location.pathname);
-  }
-})();
+  var type = nav.length > 0 ? nav[0].type : 'navigate';
+  Shiny.setInputValue(inputId, type, {priority: 'event'});
+});
 
 // Update navbar title from server
 Shiny.addCustomMessageHandler('blockr-update-navbar-title', function(title) {


### PR DESCRIPTION
## Summary

Building on #44, this changes reload semantics so that a browser reload always returns to the initial board state instead of attempting to restore from URL parameters.

- The URL observer now clears stale params on page load instead of loading a board from them, eliminating the double-reload loop
- Replaces `prev_query` / `reload_meta` URL-based version tracking with a direct `active_version` reactiveVal passed explicitly to the version history UI
- Net deletion of 35 lines by removing the load-from-URL code path and its associated re-trigger prevention logic

Closes #45