### PR TITLE
Drop brace-escaping in cnd_to_notif; use notify(glue = FALSE)

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -305,6 +305,7 @@ manage_project_server <- function(id, board, ...) {
               notify(
                 paste("Download failed:", conditionMessage(e)),
                 type = "error",
+                glue = FALSE,
                 session = session
               )
             }
@@ -340,6 +341,7 @@ manage_project_server <- function(id, board, ...) {
               notify(
                 paste("Download failed:", conditionMessage(e)),
                 type = "error",
+                glue = FALSE,
                 session = session
               )
             }
@@ -365,7 +367,7 @@ manage_project_server <- function(id, board, ...) {
           )
 
           for (err in result$errors) {
-            notify(err, type = "error", session = session)
+            notify(err, type = "error", glue = FALSE, session = session)
           }
 
           if (result$ok) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -73,15 +73,10 @@ cnd_to_notif <- function(return_val = NULL, type = "warning",
                          session = get_session()) {
 
   function(cnd) {
-    msg <- conditionMessage(cnd)
-    # Escape curly braces so cli/glue won't interpret them (e.g. JSON in
-    # Connect API error bodies like {"code":5, ...} would crash glue::glue).
-    msg <- gsub("{", "{{", msg, fixed = TRUE)
-    msg <- gsub("}", "}}", msg, fixed = TRUE)
-
     notify(
-      msg,
+      conditionMessage(cnd),
       type = type,
+      glue = FALSE,
       session = session
     )
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,17 @@
+test_that("cnd_to_notif surfaces brace-bearing condition messages literally", {
+
+  msg <- '{"code":5, "error":"server failed"}'
+
+  session <- shiny:::MockShinySession$new()
+  surfaced <- NULL
+  session$sendNotification <- function(type, message) {
+    surfaced <<- message
+    invisible()
+  }
+
+  notif <- cnd_to_notif(return_val = FALSE, type = "warning", session = session)
+
+  expect_identical(notif(simpleError(msg)), FALSE)
+  expect_identical(as.character(surfaced$html), msg)
+  expect_identical(surfaced$type, "warning")
+})


### PR DESCRIPTION
## Summary

- `cnd_to_notif()` dropped the `gsub` brace-doubling workaround and now passes `glue = FALSE` to `notify()`, so brace-bearing condition messages — e.g. JSON Connect API error bodies like `{"code":5, "error":"..."}` — surface literally instead of crashing `glue::glue()`.
- Applied the same `glue = FALSE` to the raw error/condition forwarders in `R/server.R` (download-failure handlers and the apply-error loop). The remaining `notify()` calls interpolate counts, sanitized names, or static literals, so they keep the default.
- Added a regression test that drives `cnd_to_notif()` with a brace-bearing message and asserts it surfaces literally; it fails on the pre-fix code with a `glue` parse error.

Depends on BristolMyersSquibb/blockr.core#223 (which added the `notify()` `glue` argument), now merged to `main` — so the temporary `Remotes` pin from earlier work is dropped here.

Fixes #57
