### PR TITLE
Pass the board to set_board_option_value in title-edit observer

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -569,7 +569,9 @@ manage_project_server <- function(id, board, ...) {
       # Title edit
       observeEvent(
         input$title_edit,
-        set_board_option_value("board_name", input$title_edit, session)
+        set_board_option_value(
+          "board_name", input$title_edit, board$board, session
+        )
       )
 
       # Initialize title

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -47,6 +47,32 @@ test_that("manage_project server", {
   )
 })
 
+test_that("title edit forwards a board to set_board_option_value (#60)", {
+
+  captured <- new.env()
+
+  testServer(
+    manage_project_server,
+    {
+      local_mocked_bindings(
+        set_board_option_value = function(opt, val, board, ...) {
+          captured$board <- board
+          invisible(val)
+        },
+        .package = "blockr.session"
+      )
+
+      session$setInputs(title_edit = "Renamed board")
+      session$flushReact()
+
+      expect_true(is_board(captured$board))
+    },
+    args = list(
+      board = reactiveValues(board = new_board(), board_id = "title-test")
+    )
+  )
+})
+
 test_that("manage_project ui", {
   expect_s3_class(manage_project_ui("project", new_board()), "shiny.tag.list")
 })


### PR DESCRIPTION
## Summary

- The navbar board-name input crashed the app on focus then blur: `set_board_option_value()` dispatched `is_board_locked()` on the module's `session_proxy` and aborted with "no applicable method", which made it impossible to save anything.
- The root cause is local, not in `blockr.core`: core #229 inserted a required `board` argument before `session` in `set_board_option_value(opt, val, board, session)`, but the `title_edit` observer here was never migrated off the old three-arg call, so it passed the Shiny session in the `board` slot.
- Forward `board$board` as the `board` argument, mirroring core's own board-name plugin; the title edit now honours the board lock instead of crashing on it.
- Add a regression test that fires `title_edit` and asserts `board_name` is written — it reproduces the exact `session_proxy` crash against the unfixed call.

Fixes #60