### PR TITLE
Add a Save As trigger to fork a loaded board into a new record

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,8 @@ Suggests:
     testthat (>= 3.0.0),
     blockr.dock,
     connectapi,
-    withr
+    withr,
+    xml2
 Config/testthat/edition: 3
 Remotes:
     BristolMyersSquibb/blockr.core

--- a/R/server.R
+++ b/R/server.R
@@ -16,11 +16,11 @@ manage_project_server <- function(id, board, ...) {
       refresh_trigger <- reactiveVal(0)
       save_status <- reactiveVal("Not saved")
 
-      serialize_now <- function() {
+      serialize_now <- function(id = board$board_id) {
         do.call(
           serialize_board,
           c(
-            list(board$board, board$blocks, board$board_id),
+            list(board$board, board$blocks, id),
             dot_args,
             list(session = session)
           )
@@ -154,6 +154,41 @@ manage_project_server <- function(id, board, ...) {
           new_url <- board_query_string(saved, backend)
           prev_query(new_url)
           updateQueryString(new_url, mode = "replace", session = session)
+        }
+      )
+
+      observeEvent(
+        input$save_as_btn,
+        {
+          new_id <- rand_names()
+
+          data <- tryCatch(
+            serialize_now(new_id),
+            error = cnd_to_notif(type = "error")
+          )
+
+          if (is.null(data)) {
+            return()
+          }
+
+          res <- tryCatch(
+            rack_create(
+              backend, data,
+              id = new_id, name = board_name()
+            ),
+            error = cnd_to_notif(type = "error")
+          )
+
+          if (is.null(res)) {
+            return()
+          }
+
+          forked <- rack_id_from_input(
+            backend,
+            list(id = res$id, user = res$user)
+          )
+
+          navigate_to_board(forked, backend, session)
         }
       )
 

--- a/R/server.R
+++ b/R/server.R
@@ -140,7 +140,7 @@ manage_project_server <- function(id, board, ...) {
           }
 
           notify(
-            paste("Successfully saved", board_name()),
+            sprintf("Successfully saved %s (%s)", board_name(), res$id),
             type = "message",
             session = session
           )

--- a/R/ui.R
+++ b/R/ui.R
@@ -165,15 +165,44 @@ manage_project_ui <- function(id, x) {
           ),
           class = "blockr-navbar-meta"
         ),
-        tags$button(
-          id = ns("save_btn"),
-          class = "blockr-navbar-save-btn shiny-bound-input",
-          type = "button",
-          onclick = sprintf(
-            "Shiny.setInputValue('%s', Date.now(), {priority: 'event'})",
-            ns("save_btn")
+        tags$div(
+          class = "btn-group blockr-navbar-save-group",
+          tags$button(
+            id = ns("save_btn"),
+            class = "blockr-navbar-save-btn shiny-bound-input",
+            type = "button",
+            onclick = sprintf(
+              "Shiny.setInputValue('%s', Date.now(), {priority: 'event'})",
+              ns("save_btn")
+            ),
+            bsicons::bs_icon("floppy", size = "1em")
           ),
-          bsicons::bs_icon("floppy", size = "1em")
+          tags$button(
+            class = paste(
+              "blockr-navbar-save-btn blockr-navbar-save-toggle",
+              "dropdown-toggle"
+            ),
+            type = "button",
+            `data-bs-toggle` = "dropdown",
+            `aria-expanded` = "false",
+            tags$span(class = "visually-hidden", "Toggle save menu")
+          ),
+          tags$ul(
+            class = "dropdown-menu dropdown-menu-end blockr-navbar-save-menu",
+            tags$li(
+              tags$button(
+                id = ns("save_as_btn"),
+                class = "dropdown-item",
+                type = "button",
+                onclick = sprintf(
+                  "Shiny.setInputValue('%s', Date.now(), {priority: 'event'})",
+                  ns("save_as_btn")
+                ),
+                bsicons::bs_icon("files"),
+                "Save as new workflow"
+              )
+            )
+          )
         )
       ),
       # New button

--- a/inst/assets/css/project-navbar.css
+++ b/inst/assets/css/project-navbar.css
@@ -317,6 +317,58 @@
   height: 14px;
 }
 
+/* --- Save Split Button --- */
+.blockr-navbar-save-group {
+  display: inline-flex;
+}
+
+.blockr-navbar-save-group > .blockr-navbar-save-btn:first-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.blockr-navbar-save-toggle {
+  width: 18px;
+  border-left: none;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.blockr-navbar-save-toggle::after {
+  margin: 0;
+}
+
+.blockr-navbar-save-menu {
+  min-width: 200px;
+  margin-top: 6px;
+  padding: 6px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow: 0 10px 25px -8px rgb(0 0 0 / 0.2);
+}
+
+.blockr-navbar-save-menu .dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  color: #374151;
+}
+
+.blockr-navbar-save-menu .dropdown-item:hover,
+.blockr-navbar-save-menu .dropdown-item:focus {
+  background-color: #f3f4f6;
+  color: #111827;
+}
+
+.blockr-navbar-save-menu .dropdown-item svg {
+  width: 14px;
+  height: 14px;
+  color: #6b7280;
+}
+
 /* --- New Button --- */
 .blockr-navbar-btn-new {
   display: inline-flex;

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -85,6 +85,30 @@ test_that("manage_project ui", {
   expect_s3_class(manage_project_ui("project", new_board()), "shiny.tag.list")
 })
 
+test_that("manage_project ui puts Save As in a split-button dropdown (#67)", {
+  doc <- xml2::read_html(
+    as.character(manage_project_ui("project", new_board()))
+  )
+
+  save_btn <- xml2::xml_find_all(doc, "//button[@id='project-save_btn']")
+  expect_length(save_btn, 1)
+  expect_match(xml2::xml_attr(save_btn, "onclick"), "save_btn", fixed = TRUE)
+
+  toggle <- xml2::xml_find_all(
+    doc,
+    paste0(
+      "//button[@data-bs-toggle='dropdown' and contains(",
+      "concat(' ', normalize-space(@class), ' '), ' dropdown-toggle ')]"
+    )
+  )
+  expect_length(toggle, 1)
+
+  save_as <- xml2::xml_find_all(doc, "//button[@id='project-save_as_btn']")
+  expect_length(save_as, 1)
+  expect_match(xml2::xml_attr(save_as, "class"), "dropdown-item")
+  expect_match(xml2::xml_attr(save_as, "onclick"), "save_as_btn", fixed = TRUE)
+})
+
 test_that("save persists board to backend", {
   backend <- pins::board_temp(versioned = TRUE)
   withr::local_options(blockr.session_mgmt_backend = backend)
@@ -362,6 +386,41 @@ test_that("load_version navigates to the selected version", {
   expect_s3_class(navigated, "rack_id")
   expect_identical(navigated$id, "ver-test")
   expect_identical(navigated$version, "20240101")
+})
+
+test_that("save_as forks the loaded board into a fresh record (#67)", {
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  navigated <- NULL
+  local_mocked_bindings(
+    navigate_to_board = function(id, backend, session) navigated <<- id
+  )
+
+  test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  testServer(
+    manage_project_server,
+    {
+      session$setInputs(save_btn = 1)
+      session$flushReact()
+
+      prev_query("?id=fork-origin")
+      session$setInputs(save_as_btn = 1)
+      session$flushReact()
+    },
+    args = list(
+      board = reactiveValues(board = test_board, board_id = "fork-origin")
+    )
+  )
+
+  forked <- setdiff(pins::pin_list(backend), "fork-origin")
+
+  expect_length(forked, 1)
+  expect_equal(nrow(pins::pin_versions(backend, "fork-origin")), 1)
+
+  expect_s3_class(navigated, "rack_id")
+  expect_identical(navigated$id, forked)
 })
 
 test_that("rack_loader returns a board_loader", {


### PR DESCRIPTION
## Summary

- Adds **Save As** to `manage_project`, presented as a Bootstrap split button on the Save icon — the icon still saves in place, and a caret toggle opens a dropdown holding Save As. It forks a *loaded* board into a brand-new record: mints a fresh slug-safe id (`rand_names()`), serialises the board under that id, `rack_create()`s it carrying the current display name, then navigates to the fork. After #61 the plain Save is update-in-place once a board is loaded — there was no way to fork one; this is that capability.
- The fork switches identity via `navigate_to_board()` (URL `?id=` + `session$reload()`), the module's existing idiom for `load_workflow` and version-restore. The reload is load-bearing, not cosmetic: the plugin's `board` handle is read-only, and `serve()` only re-derives `board_id` from the loaded board's embedded id at page load — so reloading onto the just-created fork is what makes the whole session (URL, `current_id()`, `board_id`, subsequent Saves) adopt the new identity consistently. A bare in-memory `board$board_id <- …` would `abort()` on the read-only handle and otherwise leave the next Save embedding the old id under the fork's key — exactly the identity drift #61 set out to kill.
- No `rack_exists()` overwrite guard: Save As mints a *random* id, not a user-chosen name, so there is no name collision to confirm — that confirm-overwrite UX is #10's domain. The fork keeps the same display name (distinct ids sharing a name is valid post-#61); renaming afterward goes through the title field.
- Tests: a server test proves the fork lands as a new record while the original is left untouched and `navigate_to_board` targets the fork (verified red against the unfixed observer), plus a parsed-DOM assertion that the navbar exposes the wired `save_as_btn`.

Stacked on #61 (`61-rack-identity`); base retargets to `main` once that lands. CI gates on `base: main`, so checks stay idle while stacked — locally the full test suite and `lint_package()` are green.

Once this lands, the deployment can drop the blunt `restore-save-as` stopgap and unpin it from blockr.uat.

Fixes #67
