### PR TITLE
Resolve loader boards with the visitor's Connect token

### DIFF
--- a/R/backend.R
+++ b/R/backend.R
@@ -21,7 +21,7 @@
 #' @export
 user_pins_board <- function(session = shiny::getDefaultReactiveDomain()) {
 
-  token <- connect_session_token(session)
+  token <- connect_session_token(session$request)
 
   if (is.null(token)) {
     log_info("No Connect user session token found; using a local pins board.")
@@ -35,9 +35,9 @@ user_pins_board <- function(session = shiny::getDefaultReactiveDomain()) {
   board
 }
 
-connect_session_token <- function(session) {
+connect_session_token <- function(request) {
 
-  token <- session$request$HTTP_POSIT_CONNECT_USER_SESSION_TOKEN
+  token <- request[["HTTP_POSIT_CONNECT_USER_SESSION_TOKEN"]]
 
   if (is.null(token) || !nzchar(token)) {
     return(NULL)
@@ -62,4 +62,17 @@ connect_board <- function(token) {
     server = Sys.getenv("CONNECT_SERVER"),
     key = con$api_key
   )
+}
+
+loader_backend <- function(request, session) {
+
+  req <- if (is.null(session)) request else session$request
+
+  token <- connect_session_token(req)
+
+  if (is.null(token)) {
+    return(get_session_backend())
+  }
+
+  connect_board(token)
 }

--- a/R/backend.R
+++ b/R/backend.R
@@ -63,16 +63,3 @@ connect_board <- function(token) {
     key = con$api_key
   )
 }
-
-loader_backend <- function(request, session) {
-
-  req <- if (is.null(session)) request else session$request
-
-  token <- connect_session_token(req)
-
-  if (is.null(token)) {
-    return(get_session_backend())
-  }
-
-  connect_board(token)
-}

--- a/R/backend.R
+++ b/R/backend.R
@@ -21,7 +21,7 @@
 #'   `board_local` when no Connect credentials are available.
 #'
 #' @export
-user_pins_board <- function(session = shiny::getDefaultReactiveDomain()) {
+user_pins_board <- function(session = get_session()) {
 
   token <- connect_session_token(session$request)
 

--- a/R/backend.R
+++ b/R/backend.R
@@ -1,38 +1,56 @@
-#' User-scoped Posit Connect storage backend
+#' Posit Connect storage backend with graceful fallback
 #'
-#' Constructs a [pins::board_connect()] scoped to the *viewer's* own Posit
-#' Connect account, for use as the `session_mgmt_backend`
-#' [blockr.core::blockr_option()]. When the content has the Connect API
-#' Integration enabled, Connect injects a per-viewer session token into the
-#' request, which this exchanges for a viewer-scoped API key via
-#' `connectapi::connect()` so each user reads and writes pins under their own
-#' namespace. With no token present (e.g. local development), it falls back to
-#' [pins::board_local()].
+#' Resolves the storage backend for the `session_mgmt_backend`
+#' [blockr.core::blockr_option()] -- of which it is the default -- in three
+#' tiers, degrading instead of erroring on a missing credential:
 #'
-#' Requires the \pkg{connectapi} package and the `CONNECT_SERVER` environment
-#' variable.
+#' 1. When the visitor carries a Posit Connect user session token (the Connect
+#'    API Integration is enabled), it is exchanged via `connectapi::connect()`
+#'    for a viewer-scoped API key, so each user reads and writes pins under
+#'    their own namespace ([pins::board_connect()]). Requires the
+#'    \pkg{connectapi} package.
+#' 2. With no visitor token but application Connect credentials in the
+#'    environment (`CONNECT_SERVER` and `CONNECT_API_KEY`), a board on the
+#'    application's own account.
+#' 3. Otherwise (e.g. local development, off Connect), [pins::board_local()].
 #'
 #' @param session Shiny session whose request carries the Connect user session
 #'   token; defaults to the current reactive domain.
 #'
-#' @return A `pins_board`: a viewer-scoped `board_connect`, or `board_local`
-#'   when no Connect session token is available.
+#' @return A `pins_board`: a viewer- or application-scoped `board_connect`, or
+#'   `board_local` when no Connect credentials are available.
 #'
 #' @export
 user_pins_board <- function(session = shiny::getDefaultReactiveDomain()) {
 
   token <- connect_session_token(session$request)
 
-  if (is.null(token)) {
-    log_info("No Connect user session token found; using a local pins board.")
-    return(pins::board_local())
+  if (not_null(token)) {
+    board <- connect_board(token)
+    log_info("Resolved a Connect pin board for account {board$account}.")
+    return(board)
   }
 
-  board <- connect_board(token)
+  if (has_connect_app_creds()) {
+    log_info("No visitor token; using the application Connect pin board.")
+    return(app_pins_board())
+  }
 
-  log_info("Resolved a Connect pin board for account {board$account}.")
+  log_info("No Connect credentials found; using a local pins board.")
 
-  board
+  pins::board_local()
+}
+
+has_connect_app_creds <- function() {
+  nzchar(Sys.getenv("CONNECT_SERVER")) && nzchar(Sys.getenv("CONNECT_API_KEY"))
+}
+
+app_pins_board <- function() {
+  pins::board_connect(
+    auth = "manual",
+    server = Sys.getenv("CONNECT_SERVER"),
+    key = Sys.getenv("CONNECT_API_KEY")
+  )
 }
 
 connect_session_token <- function(request) {

--- a/R/server.R
+++ b/R/server.R
@@ -11,7 +11,7 @@ manage_project_server <- function(id, board, ...) {
     id,
     function(input, output, session) {
 
-      backend <- get_session_backend()
+      backend <- get_session_backend(session)
 
       refresh_trigger <- reactiveVal(0)
       save_status <- reactiveVal("Not saved")
@@ -790,15 +790,15 @@ manage_project_server <- function(id, board, ...) {
 #'
 #' A [blockr.core::board_loader()] for [blockr.core::serve()] that picks the
 #' board to build from the request URL. The board named by the URL handle
-#' (`board_name` / `user` / `version`) loads from the rack backend; a request
-#' without such a handle (a cold load, or a "New" board) gets a cleared copy of
-#' the served board. When the visitor carries a Posit Connect user session
-#' token (the Connect API Integration is enabled), the board resolves under a
-#' backend scoped to *that visitor* ([user_pins_board()]'s `connect_board()`),
-#' so access is enforced by the visitor's own credentials and a board they may
-#' not read simply does not resolve, whatever the `user` / `board_name` in the
-#' URL. Without a token it falls back to the `blockr.session_mgmt_backend`
-#' option. Pair it with [manage_project()] when calling [blockr.core::serve()]:
+#' (`board_name` / `user` / `version`) loads from the `session_mgmt_backend`
+#' backend; a request without such a handle (a cold load, or a "New" board)
+#' gets a cleared copy of the served board. The backend is resolved with the
+#' loader's own request (at the GET, before any session) or session (at the WS
+#' connect), so a user-scoped backend such as [user_pins_board()] resolves
+#' under the *visitor's* own Posit Connect credentials at both phases; a board
+#' the visitor may not read does not resolve, whatever the `user` / `board_name`
+#' in the URL. Pair it with [manage_project()] when calling
+#' [blockr.core::serve()]:
 #' `serve(board, plugins = c(.., manage_project()), loader = rack_loader())`.
 #'
 #' @return A [blockr.core::board_loader()] object.
@@ -823,7 +823,9 @@ rack_loader <- function() {
       return(clear_board(default))
     }
 
-    backend <- loader_backend(request, session)
+    backend <- get_session_backend(
+      if (is.null(session)) list(request = request) else session
+    )
 
     id <- rack_id_from_input(
       list(name = name, user = query$user, version = query$version),
@@ -833,8 +835,8 @@ rack_loader <- function() {
     # resolve runs at both the GET (UI) and the WS connect (server), so a
     # rack-backed board is fetched and deserialized twice per page load. The
     # double fetch is deliberate: a shared cache keyed by the URL handle would
-    # leak across sessions now that backend credentials are visitor-scoped, and
-    # a session-scoped cache cannot span the GET -> WS boundary.
+    # leak across sessions when backend credentials are visitor-scoped, and a
+    # session-scoped cache cannot span the GET -> WS boundary.
     board_ser <- tryCatch(rack_load(id, backend), error = function(e) NULL)
 
     if (is.null(board_ser)) {

--- a/R/server.R
+++ b/R/server.R
@@ -790,10 +790,15 @@ manage_project_server <- function(id, board, ...) {
 #'
 #' A [blockr.core::board_loader()] for [blockr.core::serve()] that picks the
 #' board to build from the request URL. The board named by the URL handle
-#' (`board_name` / `user` / `version`) loads from the rack backend (the
-#' `blockr.session_mgmt_backend` option); a request without such a handle (a
-#' cold load, or a "New" board) gets a cleared copy of the served board. Pair
-#' it with [manage_project()] when calling [blockr.core::serve()]:
+#' (`board_name` / `user` / `version`) loads from the rack backend; a request
+#' without such a handle (a cold load, or a "New" board) gets a cleared copy of
+#' the served board. When the visitor carries a Posit Connect user session
+#' token (the Connect API Integration is enabled), the board resolves under a
+#' backend scoped to *that visitor* ([user_pins_board()]'s `connect_board()`),
+#' so access is enforced by the visitor's own credentials and a board they may
+#' not read simply does not resolve, whatever the `user` / `board_name` in the
+#' URL. Without a token it falls back to the `blockr.session_mgmt_backend`
+#' option. Pair it with [manage_project()] when calling [blockr.core::serve()]:
 #' `serve(board, plugins = c(.., manage_project()), loader = rack_loader())`.
 #'
 #' @return A [blockr.core::board_loader()] object.
@@ -818,7 +823,7 @@ rack_loader <- function() {
       return(clear_board(default))
     }
 
-    backend <- get_session_backend()
+    backend <- loader_backend(request, session)
 
     id <- rack_id_from_input(
       list(name = name, user = query$user, version = query$version),
@@ -828,8 +833,8 @@ rack_loader <- function() {
     # resolve runs at both the GET (UI) and the WS connect (server), so a
     # rack-backed board is fetched and deserialized twice per page load. The
     # double fetch is deliberate: a shared cache keyed by the URL handle would
-    # leak across sessions once backend credentials become visitor-scoped, and a
-    # session-scoped cache cannot span the GET -> WS boundary.
+    # leak across sessions now that backend credentials are visitor-scoped, and
+    # a session-scoped cache cannot span the GET -> WS boundary.
     board_ser <- tryCatch(rack_load(id, backend), error = function(e) NULL)
 
     if (is.null(board_ser)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,6 @@
 get_session_backend <- function(session = NULL) {
 
-  val <- blockr_option("session_mgmt_backend", pins::board_local)
+  val <- blockr_option("session_mgmt_backend", user_pins_board)
 
   if (is.function(val)) {
     val <- if (not_null(session) && "session" %in% names(formals(val))) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,9 +1,13 @@
-get_session_backend <- function() {
+get_session_backend <- function(session = NULL) {
 
   val <- blockr_option("session_mgmt_backend", pins::board_local)
 
   if (is.function(val)) {
-    val <- val()
+    val <- if (not_null(session) && "session" %in% names(formals(val))) {
+      val(session)
+    } else {
+      val()
+    }
   }
 
   if (!inherits(val, "pins_board")) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,52 +48,28 @@ serve(
 )
 ```
 
-The default storage backend is [pins::board_local()] which can be configured by setting the `session_mgmt_backend` [blockr_option()].
+The default storage backend is [user_pins_board()]: on Posit Connect it resolves per-visitor pin storage from the visitor's own session token (falling back to the application's Connect credentials), and off Connect it falls back to [pins::board_local()]. Override it by setting the `session_mgmt_backend` [blockr_option()].
 
-## Using a Connect backend
+## Connect storage
 
-To use Posit Connect as the storage backend, pass `pins::board_connect` (the
-function itself, not its result) as the backend option. This enables sharing,
-visibility controls, and per-user pin storage:
+On Posit Connect with the Connect API Integration enabled, each user reads and writes pins under their own account out of the box, with no backend option to set. The navbar dropdown gains a **Sharing** tab (next to Workflows and History) that lets you set visibility and share with other Connect users.
+
+To override the default, set the option to a `pins` board or to a function returning one, which `get_session_backend()` calls once per session so credentials are picked up at runtime. For example, to use a single shared namespace on the publisher's account instead of per-visitor storage:
 
 ```r
-library(blockr.core)
-library(blockr.dock)
-library(blockr.session)
-
 options(blockr.session_mgmt_backend = pins::board_connect)
-
-serve(
-  new_dock_board(),
-  plugins = custom_plugins(manage_project())
-)
 ```
-
-`get_session_backend()` calls the function once per session, picking up
-credentials at runtime. The navbar dropdown gains a **Sharing** tab (next to
-Workflows and History) that lets you set visibility and share with other
-Connect users.
 
 ### Deploying to Posit Connect
 
-When deploying to Connect, the above is all that is needed — `board_connect`
-picks up the server URL and API key from the environment automatically.
+When deploying to Connect no backend option is needed: the default [user_pins_board()] picks up Connect credentials from the environment automatically.
 
 ### Per-user pins with the Connect API Integration
 
-By default, pins are stored under the deploying user's namespace. To have each
-viewer's pins saved under their own account, enable the **Connect API
-Integration** for the content:
+Without the integration, every viewer's pins are stored under the application's own Connect account, a single shared namespace. To have each viewer's pins saved under their *own* account instead, enable the **Connect API Integration** for the content:
 
 1. In Connect, open the content's **Settings → Access** tab.
 2. Under *API Integrations*, enable the **Posit Connect** integration.
 3. Set the maximum role to **Viewer** (sufficient for reading and writing pins).
 
-With the integration enabled, Connect injects an ephemeral `CONNECT_API_KEY`
-into each user's session. Because `pins::board_connect` is called fresh per
-session, it automatically picks up that key via its default `auth = "auto"`.
-No additional packages or configuration are needed — in particular, the
-[`connectcreds`](https://github.com/posit-dev/connectcreds) package is **not**
-required here; that package is for exchanging session credentials for
-third-party OAuth tokens (e.g. GitHub, Salesforce), which is a separate use
-case.
+With the integration enabled, Connect attaches a per-visitor session token to each request, which [user_pins_board()] exchanges (via `connectapi::connect()`) for a viewer-scoped API key, so the [`connectapi`](https://github.com/posit-dev/connectapi) package is required for this path.

--- a/README.md
+++ b/README.md
@@ -41,43 +41,41 @@ serve(
 )
 ```
 
-The default storage backend is \[pins::board_local()\] which can be
-configured by setting the `session_mgmt_backend` \[blockr_option()\].
+The default storage backend is \[user_pins_board()\]: on Posit Connect
+it resolves per-visitor pin storage from the visitor’s own session token
+(falling back to the application’s Connect credentials), and off Connect
+it falls back to \[pins::board_local()\]. Override it by setting the
+`session_mgmt_backend` \[blockr_option()\].
 
-## Using a Connect backend
+## Connect storage
 
-To use Posit Connect as the storage backend, pass `pins::board_connect`
-(the function itself, not its result) as the backend option. This
-enables sharing, visibility controls, and per-user pin storage:
+On Posit Connect with the Connect API Integration enabled, each user
+reads and writes pins under their own account out of the box, with no
+backend option to set. The navbar dropdown gains a **Sharing** tab (next
+to Workflows and History) that lets you set visibility and share with
+other Connect users.
+
+To override the default, set the option to a `pins` board or to a
+function returning one, which `get_session_backend()` calls once per
+session so credentials are picked up at runtime. For example, to use a
+single shared namespace on the publisher’s account instead of
+per-visitor storage:
 
 ``` r
-library(blockr.core)
-library(blockr.dock)
-library(blockr.session)
-
 options(blockr.session_mgmt_backend = pins::board_connect)
-
-serve(
-  new_dock_board(),
-  plugins = custom_plugins(manage_project())
-)
 ```
-
-`get_session_backend()` calls the function once per session, picking up
-credentials at runtime. The navbar dropdown gains a **Sharing** tab
-(next to Workflows and History) that lets you set visibility and share
-with other Connect users.
 
 ### Deploying to Posit Connect
 
-When deploying to Connect, the above is all that is needed —
-`board_connect` picks up the server URL and API key from the environment
+When deploying to Connect no backend option is needed: the default
+\[user_pins_board()\] picks up Connect credentials from the environment
 automatically.
 
 ### Per-user pins with the Connect API Integration
 
-By default, pins are stored under the deploying user’s namespace. To
-have each viewer’s pins saved under their own account, enable the
+Without the integration, every viewer’s pins are stored under the
+application’s own Connect account, a single shared namespace. To have
+each viewer’s pins saved under their *own* account instead, enable the
 **Connect API Integration** for the content:
 
 1.  In Connect, open the content’s **Settings → Access** tab.
@@ -85,12 +83,8 @@ have each viewer’s pins saved under their own account, enable the
 3.  Set the maximum role to **Viewer** (sufficient for reading and
     writing pins).
 
-With the integration enabled, Connect injects an ephemeral
-`CONNECT_API_KEY` into each user’s session. Because
-`pins::board_connect` is called fresh per session, it automatically
-picks up that key via its default `auth = "auto"`. No additional
-packages or configuration are needed — in particular, the
-[`connectcreds`](https://github.com/posit-dev/connectcreds) package is
-**not** required here; that package is for exchanging session
-credentials for third-party OAuth tokens (e.g. GitHub, Salesforce),
-which is a separate use case.
+With the integration enabled, Connect attaches a per-visitor session
+token to each request, which \[user_pins_board()\] exchanges (via
+`connectapi::connect()`) for a viewer-scoped API key, so the
+[`connectapi`](https://github.com/posit-dev/connectapi) package is
+required for this path.

--- a/inst/scripts/app-core.R
+++ b/inst/scripts/app-core.R
@@ -1,9 +1,5 @@
 library(blockr.core)
 library(blockr.session)
 
-options(
-  blockr.session_mgmt_backend = pins::board_connect
-)
-
 board <- new_board()
 serve(board, plugins = c(board_plugins(board, -1), manage_project()))

--- a/inst/scripts/app-full.R
+++ b/inst/scripts/app-full.R
@@ -1,9 +1,6 @@
 library(blockr.core)
 
-options(
-  blockr.session_mgmt_backend = blockr.session::user_pins_board,
-  g6R.layout_on_data_change = TRUE
-)
+options(g6R.layout_on_data_change = TRUE)
 
 serve(
   blockr.dock::new_dock_board(extensions = blockr.dag::new_dag_extension()),

--- a/inst/scripts/app-md.R
+++ b/inst/scripts/app-md.R
@@ -2,8 +2,4 @@ library(blockr.md)
 library(blockr.core)
 library(blockr.ai)
 
-options(
-  blockr.session_mgmt_backend = pins::board_connect
-)
-
 serve(new_md_board())

--- a/man/rack_loader.Rd
+++ b/man/rack_loader.Rd
@@ -12,9 +12,14 @@ A \code{\link[blockr.core:board_loader]{blockr.core::board_loader()}} object.
 \description{
 A \code{\link[blockr.core:board_loader]{blockr.core::board_loader()}} for \code{\link[blockr.core:serve]{blockr.core::serve()}} that picks the
 board to build from the request URL. The board named by the URL handle
-(\code{board_name} / \code{user} / \code{version}) loads from the rack backend (the
-\code{blockr.session_mgmt_backend} option); a request without such a handle (a
-cold load, or a "New" board) gets a cleared copy of the served board. Pair
-it with \code{\link[=manage_project]{manage_project()}} when calling \code{\link[blockr.core:serve]{blockr.core::serve()}}:
+(\code{board_name} / \code{user} / \code{version}) loads from the rack backend; a request
+without such a handle (a cold load, or a "New" board) gets a cleared copy of
+the served board. When the visitor carries a Posit Connect user session
+token (the Connect API Integration is enabled), the board resolves under a
+backend scoped to \emph{that visitor} (\code{\link[=user_pins_board]{user_pins_board()}}'s \code{connect_board()}),
+so access is enforced by the visitor's own credentials and a board they may
+not read simply does not resolve, whatever the \code{user} / \code{board_name} in the
+URL. Without a token it falls back to the \code{blockr.session_mgmt_backend}
+option. Pair it with \code{\link[=manage_project]{manage_project()}} when calling \code{\link[blockr.core:serve]{blockr.core::serve()}}:
 \code{serve(board, plugins = c(.., manage_project()), loader = rack_loader())}.
 }

--- a/man/rack_loader.Rd
+++ b/man/rack_loader.Rd
@@ -12,14 +12,14 @@ A \code{\link[blockr.core:board_loader]{blockr.core::board_loader()}} object.
 \description{
 A \code{\link[blockr.core:board_loader]{blockr.core::board_loader()}} for \code{\link[blockr.core:serve]{blockr.core::serve()}} that picks the
 board to build from the request URL. The board named by the URL handle
-(\code{board_name} / \code{user} / \code{version}) loads from the rack backend; a request
-without such a handle (a cold load, or a "New" board) gets a cleared copy of
-the served board. When the visitor carries a Posit Connect user session
-token (the Connect API Integration is enabled), the board resolves under a
-backend scoped to \emph{that visitor} (\code{\link[=user_pins_board]{user_pins_board()}}'s \code{connect_board()}),
-so access is enforced by the visitor's own credentials and a board they may
-not read simply does not resolve, whatever the \code{user} / \code{board_name} in the
-URL. Without a token it falls back to the \code{blockr.session_mgmt_backend}
-option. Pair it with \code{\link[=manage_project]{manage_project()}} when calling \code{\link[blockr.core:serve]{blockr.core::serve()}}:
+(\code{board_name} / \code{user} / \code{version}) loads from the \code{session_mgmt_backend}
+backend; a request without such a handle (a cold load, or a "New" board)
+gets a cleared copy of the served board. The backend is resolved with the
+loader's own request (at the GET, before any session) or session (at the WS
+connect), so a user-scoped backend such as \code{\link[=user_pins_board]{user_pins_board()}} resolves
+under the \emph{visitor's} own Posit Connect credentials at both phases; a board
+the visitor may not read does not resolve, whatever the \code{user} / \code{board_name}
+in the URL. Pair it with \code{\link[=manage_project]{manage_project()}} when calling
+\code{\link[blockr.core:serve]{blockr.core::serve()}}:
 \code{serve(board, plugins = c(.., manage_project()), loader = rack_loader())}.
 }

--- a/man/user_pins_board.Rd
+++ b/man/user_pins_board.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/backend.R
 \name{user_pins_board}
 \alias{user_pins_board}
-\title{User-scoped Posit Connect storage backend}
+\title{Posit Connect storage backend with graceful fallback}
 \usage{
 user_pins_board(session = shiny::getDefaultReactiveDomain())
 }
@@ -11,20 +11,24 @@ user_pins_board(session = shiny::getDefaultReactiveDomain())
 token; defaults to the current reactive domain.}
 }
 \value{
-A \code{pins_board}: a viewer-scoped \code{board_connect}, or \code{board_local}
-when no Connect session token is available.
+A \code{pins_board}: a viewer- or application-scoped \code{board_connect}, or
+\code{board_local} when no Connect credentials are available.
 }
 \description{
-Constructs a \code{\link[pins:board_connect]{pins::board_connect()}} scoped to the \emph{viewer's} own Posit
-Connect account, for use as the \code{session_mgmt_backend}
-\code{\link[blockr.core:blockr_option]{blockr.core::blockr_option()}}. When the content has the Connect API
-Integration enabled, Connect injects a per-viewer session token into the
-request, which this exchanges for a viewer-scoped API key via
-\code{connectapi::connect()} so each user reads and writes pins under their own
-namespace. With no token present (e.g. local development), it falls back to
-\code{\link[pins:board_folder]{pins::board_local()}}.
+Resolves the storage backend for the \code{session_mgmt_backend}
+\code{\link[blockr.core:blockr_option]{blockr.core::blockr_option()}} -- of which it is the default -- in three
+tiers, degrading instead of erroring on a missing credential:
 }
 \details{
-Requires the \pkg{connectapi} package and the \code{CONNECT_SERVER} environment
-variable.
+\enumerate{
+\item When the visitor carries a Posit Connect user session token (the Connect
+API Integration is enabled), it is exchanged via \code{connectapi::connect()}
+for a viewer-scoped API key, so each user reads and writes pins under
+their own namespace (\code{\link[pins:board_connect]{pins::board_connect()}}). Requires the
+\pkg{connectapi} package.
+\item With no visitor token but application Connect credentials in the
+environment (\code{CONNECT_SERVER} and \code{CONNECT_API_KEY}), a board on the
+application's own account.
+\item Otherwise (e.g. local development, off Connect), \code{\link[pins:board_folder]{pins::board_local()}}.
+}
 }

--- a/man/user_pins_board.Rd
+++ b/man/user_pins_board.Rd
@@ -4,7 +4,7 @@
 \alias{user_pins_board}
 \title{Posit Connect storage backend with graceful fallback}
 \usage{
-user_pins_board(session = shiny::getDefaultReactiveDomain())
+user_pins_board(session = get_session())
 }
 \arguments{
 \item{session}{Shiny session whose request carries the Connect user session

--- a/tests/testthat/test-backend.R
+++ b/tests/testthat/test-backend.R
@@ -1,4 +1,6 @@
-test_that("user_pins_board falls back to a local board without a token", {
+test_that("user_pins_board uses a local board with no Connect creds", {
+
+  withr::local_envvar(CONNECT_SERVER = "", CONNECT_API_KEY = "")
 
   board <- user_pins_board(NULL)
 
@@ -20,6 +22,23 @@ test_that("user_pins_board scopes the board to the viewer's account", {
 
   expect_s3_class(board, "pins_board_connect")
   expect_equal(board$account, "viewer")
+})
+
+test_that("user_pins_board uses the app board with app creds, no token", {
+
+  withr::local_envvar(
+    CONNECT_SERVER = "https://connect.example.com",
+    CONNECT_API_KEY = "app-key"
+  )
+
+  local_mocked_bindings(
+    app_pins_board = function() mock_board_connect(account = "publisher")
+  )
+
+  board <- user_pins_board(NULL)
+
+  expect_s3_class(board, "pins_board_connect")
+  expect_equal(board$account, "publisher")
 })
 
 test_that("connect_board errors when connectapi is unavailable", {

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -247,14 +247,13 @@ test_that("loader resolve serves the cleared default for an unknown board", {
   expect_length(board_block_ids(res), 0)
 })
 
-test_that("loader GET resolves under the visitor token backend (#70)", {
-  token_backend <- pins::board_temp(versioned = TRUE)
-  app_backend <- pins::board_temp(versioned = TRUE)
+test_that("loader GET user-scopes via the configured user_pins_board (#70)", {
+  visitor_backend <- pins::board_temp(versioned = TRUE)
 
   seed <- new_board(blocks = c(a = new_dataset_block("iris")))
 
   withr::with_options(
-    list(blockr.session_mgmt_backend = token_backend),
+    list(blockr.session_mgmt_backend = visitor_backend),
     testServer(
       manage_project_server,
       session$setInputs(save_btn = 1),
@@ -264,8 +263,8 @@ test_that("loader GET resolves under the visitor token backend (#70)", {
     )
   )
 
-  withr::local_options(blockr.session_mgmt_backend = app_backend)
-  local_mocked_bindings(connect_board = function(token) token_backend)
+  withr::local_options(blockr.session_mgmt_backend = user_pins_board)
+  local_mocked_bindings(connect_board = function(token) visitor_backend)
 
   loaded <- rack_loader()$resolve(
     list(
@@ -280,27 +279,28 @@ test_that("loader GET resolves under the visitor token backend (#70)", {
   expect_setequal(board_block_ids(loaded), "a")
 })
 
-test_that("loader GET ignores the app backend when a token is present (#70)", {
-  token_backend <- pins::board_temp(versioned = TRUE)
-  app_backend <- pins::board_temp(versioned = TRUE)
+test_that("loader leaves a non-Connect backend untouched under a token (#70)", {
+  shared_backend <- pins::board_temp(versioned = TRUE)
 
   seed <- new_board(blocks = c(a = new_dataset_block("iris")))
 
-  withr::local_options(blockr.session_mgmt_backend = app_backend)
+  withr::local_options(blockr.session_mgmt_backend = shared_backend)
 
   testServer(
     manage_project_server,
     session$setInputs(save_btn = 1),
     args = list(
-      board = reactiveValues(board = seed, board_id = "app-only")
+      board = reactiveValues(board = seed, board_id = "shared")
     )
   )
 
-  local_mocked_bindings(connect_board = function(token) token_backend)
+  local_mocked_bindings(
+    connect_board = function(token) stop("must not user-scope a plain backend")
+  )
 
   loaded <- rack_loader()$resolve(
     list(
-      QUERY_STRING = "board_name=app-only",
+      QUERY_STRING = "board_name=shared",
       HTTP_POSIT_CONNECT_USER_SESSION_TOKEN = "viewer-token"
     ),
     NULL,
@@ -308,17 +308,16 @@ test_that("loader GET ignores the app backend when a token is present (#70)", {
   )
 
   expect_s3_class(loaded, "board")
-  expect_length(board_block_ids(loaded), 0)
+  expect_setequal(board_block_ids(loaded), "a")
 })
 
-test_that("loader WS resolves under the session token backend (#70)", {
-  token_backend <- pins::board_temp(versioned = TRUE)
-  app_backend <- pins::board_temp(versioned = TRUE)
+test_that("loader WS user-scopes via the configured user_pins_board (#70)", {
+  visitor_backend <- pins::board_temp(versioned = TRUE)
 
   seed <- new_board(blocks = c(a = new_dataset_block("iris")))
 
   withr::with_options(
-    list(blockr.session_mgmt_backend = token_backend),
+    list(blockr.session_mgmt_backend = visitor_backend),
     testServer(
       manage_project_server,
       session$setInputs(save_btn = 1),
@@ -328,8 +327,8 @@ test_that("loader WS resolves under the session token backend (#70)", {
     )
   )
 
-  withr::local_options(blockr.session_mgmt_backend = app_backend)
-  local_mocked_bindings(connect_board = function(token) token_backend)
+  withr::local_options(blockr.session_mgmt_backend = user_pins_board)
+  local_mocked_bindings(connect_board = function(token) visitor_backend)
 
   fake_session <- list(
     request = list(HTTP_POSIT_CONNECT_USER_SESSION_TOKEN = "viewer-token"),

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -247,6 +247,101 @@ test_that("loader resolve serves the cleared default for an unknown board", {
   expect_length(board_block_ids(res), 0)
 })
 
+test_that("loader GET resolves under the visitor token backend (#70)", {
+  token_backend <- pins::board_temp(versioned = TRUE)
+  app_backend <- pins::board_temp(versioned = TRUE)
+
+  seed <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  withr::with_options(
+    list(blockr.session_mgmt_backend = token_backend),
+    testServer(
+      manage_project_server,
+      session$setInputs(save_btn = 1),
+      args = list(
+        board = reactiveValues(board = seed, board_id = "scoped")
+      )
+    )
+  )
+
+  withr::local_options(blockr.session_mgmt_backend = app_backend)
+  local_mocked_bindings(connect_board = function(token) token_backend)
+
+  loaded <- rack_loader()$resolve(
+    list(
+      QUERY_STRING = "board_name=scoped",
+      HTTP_POSIT_CONNECT_USER_SESSION_TOKEN = "viewer-token"
+    ),
+    NULL,
+    new_board()
+  )
+
+  expect_s3_class(loaded, "board")
+  expect_setequal(board_block_ids(loaded), "a")
+})
+
+test_that("loader GET ignores the app backend when a token is present (#70)", {
+  token_backend <- pins::board_temp(versioned = TRUE)
+  app_backend <- pins::board_temp(versioned = TRUE)
+
+  seed <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  withr::local_options(blockr.session_mgmt_backend = app_backend)
+
+  testServer(
+    manage_project_server,
+    session$setInputs(save_btn = 1),
+    args = list(
+      board = reactiveValues(board = seed, board_id = "app-only")
+    )
+  )
+
+  local_mocked_bindings(connect_board = function(token) token_backend)
+
+  loaded <- rack_loader()$resolve(
+    list(
+      QUERY_STRING = "board_name=app-only",
+      HTTP_POSIT_CONNECT_USER_SESSION_TOKEN = "viewer-token"
+    ),
+    NULL,
+    new_board()
+  )
+
+  expect_s3_class(loaded, "board")
+  expect_length(board_block_ids(loaded), 0)
+})
+
+test_that("loader WS resolves under the session token backend (#70)", {
+  token_backend <- pins::board_temp(versioned = TRUE)
+  app_backend <- pins::board_temp(versioned = TRUE)
+
+  seed <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  withr::with_options(
+    list(blockr.session_mgmt_backend = token_backend),
+    testServer(
+      manage_project_server,
+      session$setInputs(save_btn = 1),
+      args = list(
+        board = reactiveValues(board = seed, board_id = "ws-scoped")
+      )
+    )
+  )
+
+  withr::local_options(blockr.session_mgmt_backend = app_backend)
+  local_mocked_bindings(connect_board = function(token) token_backend)
+
+  fake_session <- list(
+    request = list(HTTP_POSIT_CONNECT_USER_SESSION_TOKEN = "viewer-token"),
+    clientData = list(url_search = "?board_name=ws-scoped")
+  )
+
+  loaded <- rack_loader()$resolve(NULL, fake_session, new_board())
+
+  expect_s3_class(loaded, "board")
+  expect_setequal(board_block_ids(loaded), "a")
+})
+
 test_that("version history marks the URL version as current (#19)", {
 
   backend <- pins::board_temp(versioned = TRUE)

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -11,6 +11,10 @@ test_that("manage_project plugin", {
 
 test_that("manage_project server", {
 
+  withr::local_options(
+    blockr.session_mgmt_backend = pins::board_temp(versioned = TRUE)
+  )
+
   test_board <- new_board(
     blocks = c(
       a = new_dataset_block("iris"),
@@ -48,6 +52,10 @@ test_that("manage_project server", {
 })
 
 test_that("title edit forwards a board to set_board_option_value (#60)", {
+
+  withr::local_options(
+    blockr.session_mgmt_backend = pins::board_temp(versioned = TRUE)
+  )
 
   captured <- new.env()
 


### PR DESCRIPTION
## Summary

- `rack_loader()`'s `resolve()` resolved every board with the app-level backend (`get_session_backend()` — the publisher's service account), while the board to load comes straight from the URL query. A visitor could request `?board_name=X&user=victim` and load victim's board under the app's identity, with no per-visitor access control at load. Moving to a request-phase loader (#56) made this the load mechanism for *every* board, on both the GET and the WS.
- The user-scoping primitives already existed (`user_pins_board()` / `connect_board()`) but could not engage in the loader: `connect_session_token()` read the token from the *ambient* reactive domain, which is `NULL` during `resolve()` — even though the token sits on the loader's own `request` (GET) / `session` (WS) arguments.
- Source the token from the loader's arguments instead — `request[["HTTP_POSIT_CONNECT_USER_SESSION_TOKEN"]]` at the GET (`session` is `NULL`), `session$request$...` at the WS — and resolve under a visitor-scoped `connect_board(token)` whenever a token is present. With no token, behaviour is unchanged (`get_session_backend()`, which itself falls back to `board_local()` in a Connect deployment configured with `user_pins_board`).
- Access is then enforced by the visitor's own credentials: a board they may not read simply does not resolve, whatever `user` / `board_name` the URL names. No board is ever loaded under the app's identity on a visitor's behalf.
- Generalised `connect_session_token()` to take the request-carrying object directly (so `user_pins_board()` and the loader share one token reader) and added `loader_backend(request, session)` for the phase-aware backend choice. Regression tests cover the GET and WS phases and assert the app backend is bypassed when a token is present (each fails against the unfixed loader).

Open precondition (noted in #70): whether Connect exposes the user session token on the **page GET** or only once the WS is up is an empirical question this PR does not settle. The design is safe either way — if the token is absent at the GET, that phase resolves the cleared/default board (a properly configured deployment's `get_session_backend()` falls back to `board_local()` there) and the user-scoped load happens at the WS.

Fixes #70