### PR TITLE
Migrate to roxygen2 8.0.0 and regenerate man/

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: Provides a "preserve_board" module for blockr apps to save and
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+RoxygenNote: 8.0.0
 Imports:
     blockr.core (>= 0.1.3),
     shiny,

--- a/man/blockr.session-package.Rd
+++ b/man/blockr.session-package.Rd
@@ -11,5 +11,10 @@ Provides a "preserve_board" module for blockr apps to save and manage projects a
 \author{
 \strong{Maintainer}: Nicolas Bennett \email{nicolas@cynkra.com}
 
+Authors:
+\itemize{
+  \item Nicolas Bennett \email{nicolas@cynkra.com}
+}
+
 }
 \keyword{internal}

--- a/man/user_pins_board.Rd
+++ b/man/user_pins_board.Rd
@@ -29,6 +29,6 @@ their own namespace (\code{\link[pins:board_connect]{pins::board_connect()}}). R
 \item With no visitor token but application Connect credentials in the
 environment (\code{CONNECT_SERVER} and \code{CONNECT_API_KEY}), a board on the
 application's own account.
-\item Otherwise (e.g. local development, off Connect), \code{\link[pins:board_folder]{pins::board_local()}}.
+\item Otherwise (e.g. local development, off Connect), \code{\link[pins:board_local]{pins::board_local()}}.
 }
 }


### PR DESCRIPTION
## Summary

- Bump `RoxygenNote` to 8.0.0 and regenerate `man/` under the new pin, as a dedicated PR so the mechanical diff stays off unrelated feature work.
- `pins::board_local()` now links to its own help topic (`\link[pins:board_local]`) rather than `board_folder`, the `\link`-target resolution described in BristolMyersSquibb/blockr.core#210.
- The package doc gains the roxygen2 8.0.0 `Authors:` block for the sole `aut`+`cre` person. No data objects are documented, so the `\docType{data}` / `\format{}` / `\keyword{datasets}` drop does not apply here.

Fixes #75
