### PR TITLE
Migrate DESCRIPTION to Config/roxygen2/version field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ Description: Provides a "preserve_board" module for blockr apps to save and
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 8.0.0
 Imports:
     blockr.core (>= 0.1.3),
     shiny,
@@ -34,3 +33,4 @@ Suggests:
 Config/testthat/edition: 3
 Remotes:
     BristolMyersSquibb/blockr.core
+Config/roxygen2/version: 8.0.0


### PR DESCRIPTION
## Summary

- roxygen2 8.0.0 records its version under `Config/roxygen2/version` and drops `RoxygenNote` on migration. #76 hand-edited the version to `8.0.0` before documenting, so recorded == running and the migration was suppressed, leaving the deprecated field.
- Drop the `RoxygenNote` line and let `roxygenise()` write `Config/roxygen2/version: 8.0.0`. DESCRIPTION-only — `man/` is already 8.0.0 output, so there is no doc churn.
- Mirrors BristolMyersSquibb/blockr.core#250.

Fixes #77
