### PR TITLE
Workflow menu: search-first, always-scrollable list (no recent-4 cap)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.session
 Title: Session management for blockr
-Version: 0.0.2
+Version: 0.0.1
 Authors@R:
     c(person(given = "Nicolas",
              family = "Bennett",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.session
 Title: Session management for blockr
-Version: 0.0.1
+Version: 0.0.2
 Authors@R:
     c(person(given = "Nicolas",
              family = "Bennett",

--- a/R/server.R
+++ b/R/server.R
@@ -217,12 +217,13 @@ manage_project_server <- function(id, board, ...) {
 
           tagList(
             lapply(
-              seq_len(min(length(workflows), 4L)),
+              seq_along(workflows),
               function(i) {
                 wf <- workflows[[i]]
                 wf_time <- record_time_ago(wf)
                 tags$div(
                   class = "blockr-workflow-item",
+                  `data-name` = tolower(coal(wf$name, "")),
                   onclick = shiny_input_obj_js(
                     session$ns("load_workflow"),
                     id = wf$id,

--- a/R/server.R
+++ b/R/server.R
@@ -200,53 +200,92 @@ manage_project_server <- function(id, board, ...) {
         }
       )
 
+      all_workflows <- reactive({
+        refresh_trigger()
+        tryCatch(rack_list(backend), error = function(e) list())
+      })
+
+      workflow_query <- debounce(
+        reactive(coal(input$workflow_filter, "")),
+        250
+      )
+
+      filtered_workflows <- reactive({
+
+        query <- tolower(trimws(workflow_query()))
+
+        if (!nzchar(query)) {
+          return(all_workflows())
+        }
+
+        Filter(
+          function(wf) grepl(query, tolower(coal(wf$name, "")), fixed = TRUE),
+          all_workflows()
+        )
+      })
+
+      workflow_batch <- 10L
+      n_shown <- reactiveVal(workflow_batch)
+
+      observeEvent(
+        list(workflow_query(), refresh_trigger()),
+        n_shown(workflow_batch)
+      )
+
+      observeEvent(
+        input$workflow_load_more,
+        {
+          total <- length(filtered_workflows())
+          n_shown(min(n_shown() + workflow_batch, total))
+        }
+      )
+
+      output$workflow_count <- renderText(
+        {
+          total <- length(all_workflows())
+
+          if (total == 0L) {
+            return("")
+          }
+
+          if (nzchar(trimws(workflow_query()))) {
+            paste0(length(filtered_workflows()), " / ", total)
+          } else {
+            as.character(total)
+          }
+        }
+      )
+
       output$recent_workflows <- renderUI(
         {
-          refresh_trigger()
-
-          workflows <- tryCatch(
-            rack_list(backend),
-            error = function(e) list()
-          )
-
-          if (length(workflows) == 0L) {
+          if (length(all_workflows()) == 0L) {
             return(
               tags$div(class = "blockr-workflow-empty", "No saved workflows")
             )
           }
 
-          tagList(
-            lapply(
-              seq_along(workflows),
-              function(i) {
-                wf <- workflows[[i]]
-                wf_time <- record_time_ago(wf)
-                tags$div(
-                  class = "blockr-workflow-item",
-                  `data-name` = tolower(coal(wf$name, "")),
-                  onclick = shiny_input_obj_js(
-                    session$ns("load_workflow"),
-                    id = wf$id,
-                    user = coal(wf$user, "")
-                  ),
-                  tags$div(
-                    class = "blockr-workflow-item-content",
-                    tags$div(
-                      class = "blockr-workflow-name",
-                      wf$name
-                    ),
-                    tags$div(class = "blockr-workflow-meta", wf_time)
-                  ),
-                  tags$a(
-                    class = "blockr-open-newtab",
-                    href = board_query_string(wf, backend),
-                    target = "_blank",
-                    onclick = "event.stopPropagation();",
-                    bsicons::bs_icon("box-arrow-up-right", size = "0.75em")
-                  )
-                )
-              }
+          matches <- filtered_workflows()
+
+          if (length(matches) == 0L) {
+            return(
+              tags$div(
+                class = "blockr-workflow-noresults",
+                "No workflows match your search"
+              )
             )
+          }
+
+          shown <- matches[seq_len(min(n_shown(), length(matches)))]
+
+          tagList(
+            lapply(shown, workflow_item, backend, session$ns),
+            if (length(matches) > length(shown)) {
+              tags$div(
+                class = "blockr-workflow-sentinel",
+                `data-input-id` = session$ns("workflow_load_more"),
+                tags$div(class = "blockr-workflow-spinner")
+              )
+            }
           )
         }
       )
@@ -991,6 +1030,30 @@ refuse_incompatible_load <- function(cnd, session) {
     type = "warning",
     glue = FALSE,
     session = session
+  )
+}
+
+workflow_item <- function(wf, backend, ns) {
+
+  tags$div(
+    class = "blockr-workflow-item",
+    onclick = shiny_input_obj_js(
+      ns("load_workflow"),
+      id = wf$id,
+      user = coal(wf$user, "")
+    ),
+    tags$div(
+      class = "blockr-workflow-item-content",
+      tags$div(class = "blockr-workflow-name", wf$name),
+      tags$div(class = "blockr-workflow-meta", record_time_ago(wf))
+    ),
+    tags$a(
+      class = "blockr-open-newtab",
+      href = board_query_string(wf, backend),
+      target = "_blank",
+      onclick = "event.stopPropagation();",
+      bsicons::bs_icon("box-arrow-up-right", size = "0.75em")
+    )
   )
 }
 

--- a/R/ui.R
+++ b/R/ui.R
@@ -61,10 +61,33 @@ manage_project_ui <- function(id, x) {
           tags$div(
             id = ns("panel_workflows"),
             class = "blockr-tab-panel",
-            tags$div(class = "blockr-workflows-section", "RECENT"),
+            # Sticky search on top of an always-scrollable list: every workflow
+            # is shown most-recent-first (no recent-4 cap), and typing filters
+            # the list in place, client-side.
+            tags$div(
+              class = "blockr-workflow-search-wrap",
+              tags$div(
+                class = "blockr-workflow-search",
+                bsicons::bs_icon("search", size = "0.9em"),
+                tags$input(
+                  id = ns("workflow_filter"),
+                  type = "text",
+                  class = "blockr-workflow-search-input",
+                  placeholder = "Search workflows...",
+                  autocomplete = "off",
+                  oninput = "blockrFilterWorkflows(this)",
+                  onkeydown = "blockrWorkflowSearchKey(event, this)"
+                ),
+                tags$span(class = "blockr-workflow-count")
+              )
+            ),
             tags$div(
               class = "blockr-workflows-list",
               uiOutput(ns("recent_workflows"))
+            ),
+            tags$div(
+              class = "blockr-workflow-noresults",
+              "No workflows match your search"
             ),
             tags$div(
               class = "blockr-tab-footer",
@@ -76,7 +99,7 @@ manage_project_ui <- function(id, x) {
                   return false;",
                   ns("view_all_workflows")
                 ),
-                "View all workflows ",
+                "Manage workflows ",
                 bsicons::bs_icon("arrow-right")
               )
             )

--- a/R/ui.R
+++ b/R/ui.R
@@ -61,9 +61,9 @@ manage_project_ui <- function(id, x) {
           tags$div(
             id = ns("panel_workflows"),
             class = "blockr-tab-panel",
-            # Sticky search on top of an always-scrollable list: every workflow
-            # is shown most-recent-first (no recent-4 cap), and typing filters
-            # the list in place, client-side.
+            # Sticky search over the full workflow list. Typing filters
+            # server-side; the list renders a window and materializes more as
+            # you scroll (see project-navbar.js).
             tags$div(
               class = "blockr-workflow-search-wrap",
               tags$div(
@@ -75,19 +75,22 @@ manage_project_ui <- function(id, x) {
                   class = "blockr-workflow-search-input",
                   placeholder = "Search workflows...",
                   autocomplete = "off",
-                  oninput = "blockrFilterWorkflows(this)",
+                  oninput = sprintf(
+                    "Shiny.setInputValue('%s', this.value,
+                    {priority: 'event'})",
+                    ns("workflow_filter")
+                  ),
                   onkeydown = "blockrWorkflowSearchKey(event, this)"
                 ),
-                tags$span(class = "blockr-workflow-count")
+                tags$span(
+                  class = "blockr-workflow-count",
+                  textOutput(ns("workflow_count"), inline = TRUE)
+                )
               )
             ),
             tags$div(
               class = "blockr-workflows-list",
               uiOutput(ns("recent_workflows"))
-            ),
-            tags$div(
-              class = "blockr-workflow-noresults",
-              "No workflows match your search"
             ),
             tags$div(
               class = "blockr-tab-footer",

--- a/inst/assets/css/project-navbar.css
+++ b/inst/assets/css/project-navbar.css
@@ -32,6 +32,10 @@
   border-bottom: 1px solid #e5e7eb;
   background: white;
   padding: 0 8px;
+  /* the tab bar is the top element; round its corners so the dropdown's
+     rounded top corners aren't squared off by its background */
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
 }
 
 .blockr-tab {
@@ -102,7 +106,74 @@
 }
 
 .blockr-workflows-list {
-  margin-bottom: 16px;
+  margin-bottom: 8px;
+}
+
+/* Sticky search on top of the scrollable workflow list (variant A) */
+.blockr-workflow-search-wrap {
+  position: sticky;
+  top: -8px;
+  z-index: 3;
+  background: #fff;
+  margin: -8px -8px 8px;
+  padding: 8px;
+  border-bottom: 1px solid #f1f3f5;
+}
+
+.blockr-workflow-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #f3f4f6;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 7px 10px;
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.blockr-workflow-search:focus-within {
+  background: #fff;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgb(37 99 235 / 0.12);
+}
+
+.blockr-workflow-search svg {
+  color: #9ca3af;
+  flex: none;
+}
+
+.blockr-workflow-search-input {
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: 14px;
+  width: 100%;
+  color: #111827;
+  font-family: inherit;
+}
+
+.blockr-workflow-search-input::placeholder {
+  color: #9ca3af;
+}
+
+.blockr-workflow-count {
+  font-size: 11px;
+  color: #9ca3af;
+  flex: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.blockr-workflow-noresults {
+  display: none;
+  color: #9ca3af;
+  font-style: italic;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+
+.blockr-workflow-item.blockr-hi {
+  background-color: #eef2ff;
 }
 
 /* Individual workflow item */
@@ -178,10 +249,20 @@
   text-decoration: none;
 }
 
-/* Footer link */
+/* Footer link: pinned to the bottom of the scrolling panel so "Manage
+   workflows" stays reachable no matter how long the list is. */
 .blockr-tab-footer {
+  position: sticky;
+  bottom: -8px;
+  z-index: 3;
+  background: #fff;
+  margin: 8px -8px -8px;
   padding: 12px;
   border-top: 1px solid #e5e7eb;
+  /* full-bleed footer reaches the container edge, so round its bottom to keep
+     the dropdown's rounded corners */
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
 }
 
 .blockr-workflows-link {

--- a/inst/assets/css/project-navbar.css
+++ b/inst/assets/css/project-navbar.css
@@ -165,11 +165,33 @@
 }
 
 .blockr-workflow-noresults {
-  display: none;
   color: #9ca3af;
   font-style: italic;
   padding: 10px 12px;
   font-size: 13px;
+}
+
+/* Infinite-scroll sentinel: a scroll into view asks the server for more */
+.blockr-workflow-sentinel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+}
+
+.blockr-workflow-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #e5e7eb;
+  border-top-color: #9ca3af;
+  border-radius: 50%;
+  animation: blockr-workflow-spin 0.7s linear infinite;
+}
+
+@keyframes blockr-workflow-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .blockr-workflow-item.blockr-hi {

--- a/inst/assets/js/project-navbar.js
+++ b/inst/assets/js/project-navbar.js
@@ -9,3 +9,95 @@ Shiny.addCustomMessageHandler('blockr-update-navbar-title', function(title) {
     el.value = title;
   });
 });
+
+// --- Workflow list search (variant A) -------------------------------------
+// Purely client-side: the server renders every workflow (data-name carries the
+// lowercased title); typing hides non-matches, so filtering costs no round-trip.
+
+function blockrWorkflowPanel(el) {
+  return el.closest('.blockr-tab-panel');
+}
+
+function blockrFilterWorkflows(input) {
+  var panel = blockrWorkflowPanel(input);
+  if (!panel) return;
+
+  var query = input.value.trim().toLowerCase();
+  var items = panel.querySelectorAll('.blockr-workflow-item');
+  var shown = 0;
+
+  items.forEach(function(item) {
+    var name = item.getAttribute('data-name') || '';
+    var match = !query || name.indexOf(query) !== -1;
+    item.style.display = match ? '' : 'none';
+    item.classList.remove('blockr-hi');
+    if (match) shown++;
+  });
+
+  var noresults = panel.querySelector('.blockr-workflow-noresults');
+  if (noresults) {
+    noresults.style.display = (shown === 0 && items.length > 0) ? 'block' : 'none';
+  }
+
+  var count = panel.querySelector('.blockr-workflow-count');
+  if (count) {
+    if (!items.length) {
+      count.textContent = '';
+    } else {
+      count.textContent = query ? (shown + ' / ' + items.length)
+                                : String(items.length);
+    }
+  }
+}
+
+function blockrWorkflowSearchKey(event, input) {
+  if (['ArrowDown', 'ArrowUp', 'Enter'].indexOf(event.key) === -1) return;
+
+  var panel = blockrWorkflowPanel(input);
+  if (!panel) return;
+
+  var visible = Array.prototype.filter.call(
+    panel.querySelectorAll('.blockr-workflow-item'),
+    function(item) { return item.style.display !== 'none'; }
+  );
+  if (!visible.length) return;
+
+  var current = -1;
+  for (var i = 0; i < visible.length; i++) {
+    if (visible[i].classList.contains('blockr-hi')) { current = i; break; }
+  }
+
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    (visible[current] || visible[0]).click();
+    return;
+  }
+
+  event.preventDefault();
+  if (current >= 0) visible[current].classList.remove('blockr-hi');
+
+  var next;
+  if (event.key === 'ArrowDown') {
+    next = current < 0 ? 0 : Math.min(current + 1, visible.length - 1);
+  } else {
+    next = current <= 0 ? 0 : current - 1;
+  }
+
+  visible[next].classList.add('blockr-hi');
+  visible[next].scrollIntoView({ block: 'nearest' });
+}
+
+// Focus the search when the dropdown opens (only if the Workflows panel is the
+// visible one) and re-apply any active filter after the list re-renders.
+document.addEventListener('shown.bs.dropdown', function(event) {
+  // shown.bs.dropdown fires on the toggle button; the search input lives in the
+  // sibling menu, so scope the lookup to the shared .dropdown container.
+  var root = event.target.closest('.dropdown') || document;
+  var input = root.querySelector(
+    '.blockr-tab-panel:not(.blockr-tab-panel-hidden) .blockr-workflow-search-input'
+  );
+  if (!input) return;
+  blockrFilterWorkflows(input);
+  input.focus();
+  input.select();
+});

--- a/inst/assets/js/project-navbar.js
+++ b/inst/assets/js/project-navbar.js
@@ -10,44 +10,13 @@ Shiny.addCustomMessageHandler('blockr-update-navbar-title', function(title) {
   });
 });
 
-// --- Workflow list search (variant A) -------------------------------------
-// Purely client-side: the server renders every workflow (data-name carries the
-// lowercased title); typing hides non-matches, so filtering costs no round-trip.
+// --- Workflow list: keyboard nav + infinite scroll ------------------------
+// The server renders a window of the (server-filtered) list plus a sentinel at
+// the bottom; scrolling the sentinel into view asks the server for the next
+// batch, which it appends. Search is a server-side Shiny input.
 
 function blockrWorkflowPanel(el) {
   return el.closest('.blockr-tab-panel');
-}
-
-function blockrFilterWorkflows(input) {
-  var panel = blockrWorkflowPanel(input);
-  if (!panel) return;
-
-  var query = input.value.trim().toLowerCase();
-  var items = panel.querySelectorAll('.blockr-workflow-item');
-  var shown = 0;
-
-  items.forEach(function(item) {
-    var name = item.getAttribute('data-name') || '';
-    var match = !query || name.indexOf(query) !== -1;
-    item.style.display = match ? '' : 'none';
-    item.classList.remove('blockr-hi');
-    if (match) shown++;
-  });
-
-  var noresults = panel.querySelector('.blockr-workflow-noresults');
-  if (noresults) {
-    noresults.style.display = (shown === 0 && items.length > 0) ? 'block' : 'none';
-  }
-
-  var count = panel.querySelector('.blockr-workflow-count');
-  if (count) {
-    if (!items.length) {
-      count.textContent = '';
-    } else {
-      count.textContent = query ? (shown + ' / ' + items.length)
-                                : String(items.length);
-    }
-  }
 }
 
 function blockrWorkflowSearchKey(event, input) {
@@ -56,48 +25,98 @@ function blockrWorkflowSearchKey(event, input) {
   var panel = blockrWorkflowPanel(input);
   if (!panel) return;
 
-  var visible = Array.prototype.filter.call(
-    panel.querySelectorAll('.blockr-workflow-item'),
-    function(item) { return item.style.display !== 'none'; }
+  var items = Array.prototype.slice.call(
+    panel.querySelectorAll('.blockr-workflow-item')
   );
-  if (!visible.length) return;
+  if (!items.length) return;
 
   var current = -1;
-  for (var i = 0; i < visible.length; i++) {
-    if (visible[i].classList.contains('blockr-hi')) { current = i; break; }
+  for (var i = 0; i < items.length; i++) {
+    if (items[i].classList.contains('blockr-hi')) { current = i; break; }
   }
 
   if (event.key === 'Enter') {
-    event.preventDefault();
-    (visible[current] || visible[0]).click();
+    // Act only on an explicitly highlighted row, so a stray Enter in the search
+    // box never navigates away from the current board.
+    if (current >= 0) {
+      event.preventDefault();
+      items[current].click();
+    }
     return;
   }
 
   event.preventDefault();
-  if (current >= 0) visible[current].classList.remove('blockr-hi');
+  if (current >= 0) items[current].classList.remove('blockr-hi');
 
   var next;
   if (event.key === 'ArrowDown') {
-    next = current < 0 ? 0 : Math.min(current + 1, visible.length - 1);
+    next = current < 0 ? 0 : Math.min(current + 1, items.length - 1);
   } else {
     next = current <= 0 ? 0 : current - 1;
   }
 
-  visible[next].classList.add('blockr-hi');
-  visible[next].scrollIntoView({ block: 'nearest' });
+  items[next].classList.add('blockr-hi');
+  items[next].scrollIntoView({ block: 'nearest' });
 }
 
-// Focus the search when the dropdown opens (only if the Workflows panel is the
-// visible one) and re-apply any active filter after the list re-renders.
+// The IntersectionObserver on the sentinel (a fresh node each render). Root is
+// the scrolling panel, so it fires near the bottom; a still-visible sentinel
+// keeps materializing batches until the panel fills.
+var blockrSentinelObserver = null;
+
+function blockrArmWorkflowSentinel() {
+  if (blockrSentinelObserver) blockrSentinelObserver.disconnect();
+
+  var sentinel = document.querySelector('.blockr-workflow-sentinel');
+  if (!sentinel) return;
+
+  blockrSentinelObserver = new IntersectionObserver(
+    function(entries) {
+      entries.forEach(function(entry) {
+        if (entry.isIntersecting) {
+          Shiny.setInputValue(
+            sentinel.getAttribute('data-input-id'),
+            Date.now(),
+            { priority: 'event' }
+          );
+        }
+      });
+    },
+    { root: sentinel.closest('.blockr-tab-panel'), rootMargin: '120px' }
+  );
+
+  blockrSentinelObserver.observe(sentinel);
+}
+
+// Re-arm whenever the list re-renders. A MutationObserver on the static list
+// container catches every server render (open, load-more, filter). We use it
+// rather than shiny:value, which is a jQuery event that addEventListener misses.
+function blockrWatchWorkflowLists() {
+  document.querySelectorAll('.blockr-workflows-list').forEach(function(list) {
+    if (list.dataset.blockrWatched) return;
+    list.dataset.blockrWatched = '1';
+    new MutationObserver(blockrArmWorkflowSentinel).observe(
+      list,
+      { childList: true, subtree: true }
+    );
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', blockrWatchWorkflowLists);
+} else {
+  blockrWatchWorkflowLists();
+}
+
+// Focus the search when the dropdown opens, if the Workflows panel is visible.
 document.addEventListener('shown.bs.dropdown', function(event) {
-  // shown.bs.dropdown fires on the toggle button; the search input lives in the
-  // sibling menu, so scope the lookup to the shared .dropdown container.
+  blockrWatchWorkflowLists();
+
   var root = event.target.closest('.dropdown') || document;
   var input = root.querySelector(
     '.blockr-tab-panel:not(.blockr-tab-panel-hidden) .blockr-workflow-search-input'
   );
   if (!input) return;
-  blockrFilterWorkflows(input);
   input.focus();
   input.select();
 });

--- a/tests/testthat/test-menu.R
+++ b/tests/testthat/test-menu.R
@@ -1,0 +1,78 @@
+test_that("workflow menu windows results and filters server-side", {
+
+  withr::local_options(
+    blockr.session_mgmt_backend = pins::board_temp(versioned = TRUE)
+  )
+
+  records <- lapply(
+    seq_len(25L),
+    function(i) {
+      new_rack_record(
+        id = sprintf("wf-%02d", i),
+        name = if (i <= 5L) sprintf("alpha-%d", i) else sprintf("beta-%d", i),
+        user = "tester",
+        saved = Sys.time()
+      )
+    }
+  )
+
+  n_items <- function(out) {
+    html <- paste(as.character(out), collapse = "")
+    hits <- gregexpr("class=\"blockr-workflow-item\"", html, fixed = TRUE)[[1L]]
+    if (length(hits) == 1L && hits == -1L) 0L else length(hits)
+  }
+
+  local_mocked_bindings(
+    rack_list = function(backend, ...) records,
+    board_query_string = function(x, backend, ...) "?board=test",
+    .package = "blockr.session"
+  )
+
+  testServer(
+    manage_project_server,
+    {
+      session$flushReact()
+
+      expect_length(all_workflows(), 25L)
+      expect_identical(n_shown(), 10L)
+      expect_identical(n_items(output$recent_workflows), 10L)
+      expect_match(
+        paste(as.character(output$recent_workflows), collapse = ""),
+        "blockr-workflow-sentinel"
+      )
+
+      session$setInputs(workflow_load_more = 1)
+      session$flushReact()
+
+      expect_identical(n_shown(), 20L)
+      expect_identical(n_items(output$recent_workflows), 20L)
+
+      session$setInputs(workflow_filter = "alpha")
+      session$elapse(300)
+      session$flushReact()
+
+      expect_length(filtered_workflows(), 5L)
+      expect_identical(n_shown(), 10L)
+      expect_identical(n_items(output$recent_workflows), 5L)
+      expect_identical(output$workflow_count, "5 / 25")
+      expect_no_match(
+        paste(as.character(output$recent_workflows), collapse = ""),
+        "blockr-workflow-sentinel"
+      )
+
+      session$setInputs(workflow_filter = "zzz")
+      session$elapse(300)
+      session$flushReact()
+
+      expect_length(filtered_workflows(), 0L)
+      expect_identical(n_items(output$recent_workflows), 0L)
+      expect_match(
+        paste(as.character(output$recent_workflows), collapse = ""),
+        "blockr-workflow-noresults"
+      )
+    },
+    args = list(
+      board = reactiveValues(board = new_board(), board_id = "menu-test")
+    )
+  )
+})


### PR DESCRIPTION
The Workflows dropdown showed only the 4 most recent workflows; anything older required the "View all" modal. Replace that with variant A + always-on scroll: a sticky search box on top of a list that renders every workflow, most-recent-first, scrollable from the start.

- ui.R: sticky `.blockr-workflow-search-wrap` on top of the panel; the recent list becomes the full list; footer relabelled "View all workflows" -> "Manage workflows" (the modal is now for bulk upload/delete, not the only path to older workflows)
- server.R: render all workflows (seq_along, was min(.,4L)); each item carries data-name for client-side filtering
- project-navbar.js: blockrFilterWorkflows (hide non-matches, live count, no-results state), blockrWorkflowSearchKey (Up/Down/Enter), and autofocus-on-open scoped to the shared .dropdown container
- project-navbar.css: search field + focus ring, sticky top for search and sticky bottom for the footer (so "Manage workflows" stays reachable no matter how long the list is), highlight row, count, no-results
- bump Version 0.0.1 -> 0.0.2 so the htmlDependency busts the browser cache for the edited css/js

Filtering and keyboard nav are entirely client-side -> no round-trip per keystroke. Verified headless (18 seeded workflows): all 18 render, panel scrolls from the start, search + footer stay pinned, "lab" filters to 1/18, no-results shows, arrow keys highlight, search autofocuses on open.

Depends for scale on the workflow index (feat/workflow-index-pin): rendering all workflows moves the modal's O(N) render cost onto every dropdown render, which is only cheap once rack_list() reads the index. Land together.