### PR TITLE
Paginate Connect user search to avoid silent truncation

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -350,8 +350,7 @@ rack_shares.rack_id_pins_connect <- function(id, backend, ...) {
 
 #' @export
 rack_find_users.pins_board_connect <- function(backend, query, ...) {
-  result <- connect_api(backend, "GET /users", query = list(prefix = query))
-  result$results
+  connect_api_paged(backend, "GET /users", query = list(prefix = query))
 }
 
 # Connect API helpers (internal) -------------------------------------------
@@ -379,6 +378,42 @@ connect_api <- function(board, route, ..., body = NULL, query = NULL,
 
   resp <- httr2::req_perform(req)
   httr2::resp_body_json(resp)
+}
+
+connect_api_paged <- function(board, route, query = NULL,
+                              env = parent.frame()) {
+
+  page_size <- 500L
+
+  results <- list()
+  page <- 1L
+
+  repeat {
+
+    resp <- connect_api(
+      board, route,
+      query = c(query, list(page_number = page, page_size = page_size)),
+      env = env
+    )
+
+    batch <- resp$results
+
+    if (!length(batch)) {
+      break
+    }
+
+    results <- c(results, batch)
+
+    total <- resp$total
+
+    if (!is_number(total) || length(results) >= total) {
+      break
+    }
+
+    page <- page + 1L
+  }
+
+  results
 }
 
 connect_content_find <- function(board, name) {

--- a/tests/testthat/test-pins.R
+++ b/tests/testthat/test-pins.R
@@ -1859,3 +1859,41 @@ test_that("rack_find_users on Connect returns users from API", {
   expect_equal(users[[1L]]$username, "user_a")
   expect_equal(users[[1L]]$first_name, "Alice")
 })
+
+test_that("rack_find_users pages through every result", {
+
+  board <- mock_board_connect()
+
+  pages <- list(
+    list(
+      results = list(
+        list(username = "user_1"),
+        list(username = "user_2")
+      ),
+      current_page = 1L,
+      total = 3L
+    ),
+    list(
+      results = list(
+        list(username = "user_3")
+      ),
+      current_page = 2L,
+      total = 3L
+    )
+  )
+
+  requested <- integer()
+
+  local_mocked_bindings(
+    connect_api = function(board, route, ..., query = NULL) {
+      page <- coal(query$page_number, 1L, fail_all = FALSE)
+      requested <<- c(requested, page)
+      pages[[page]]
+    }
+  )
+
+  users <- rack_find_users(board, "user")
+
+  expect_equal(chr_xtr(users, "username"), c("user_1", "user_2", "user_3"))
+  expect_equal(requested, c(1L, 2L))
+})


### PR DESCRIPTION
## Summary

- `rack_find_users` (Connect user search, `GET /users`) read only the first response page and dropped every match past it. `GET /users` is offset-paginated behind a `{results, current_page, total}` envelope with a default `page_size` of 500, so on a large instance the sharing user-search silently returned a truncated list. A new internal `connect_api_paged()` follows pages to exhaustion — stopping when a page is empty or the accumulated count reaches `total` — and user search now routes through it.
- The issue also flagged the two `GET /content` readers (`rack_list`, `connect_content_titles`), but those are deliberately left on the single-shot path. `GET /content` is not one of Connect's paginated endpoints: it returns the complete set in one bare-array response. `connectapi::get_content()` and `pins::rsc_content_find()` both issue a single un-paged GET, and Connect's pagination cookbook documents only `/v1/users` (offset) and `/v1/audit_logs` (keyset) as paginated. Routing `/content` through a page loop would gain no correctness and risk an infinite loop if the endpoint ignored the paging params — which is why `connect_api_paged()` keys on the `results`/`total` envelope that only the paginated endpoints return.
- Added a regression test driving `rack_find_users` across a two-page mock, asserting it concatenates every page and stops at `total`; confirmed it fails against the pre-fix one-shot read.

Fixes #87
