### PR TITLE
Mark blockr workflows with a configurable Connect tag

### DIFF
--- a/R/backend.R
+++ b/R/backend.R
@@ -14,6 +14,11 @@
 #'    application's own account.
 #' 3. Otherwise (e.g. local development, off Connect), [pins::board_local()].
 #'
+#' Set the `session_connect_tag` [blockr.core::blockr_option()] to an existing
+#' Connect tag's name (or a `"Category/Name"` path) to have the workflow listing
+#' filter server-side by that native tag; saves then apply it. Unset, the
+#' listing returns every pin and checks blockr membership only on load.
+#'
 #' @param session Shiny session whose request carries the Connect user session
 #'   token; defaults to the current reactive domain.
 #'

--- a/R/connect.R
+++ b/R/connect.R
@@ -88,14 +88,40 @@ rack_list.pins_board_connect <- function(backend, tags = NULL, ...) {
     return(connect_list_tagged(backend, tags))
   }
 
+  tag_id <- connect_tag_id(backend)
+
+  if (not_null(tag_id)) {
+    return(connect_list_by_tag(backend, tag_id))
+  }
+
+  connect_list_all_pins(backend)
+}
+
+connect_list_by_tag <- function(backend, tag_id) {
+
+  items <- tryCatch(
+    connect_api(backend, "GET /tags/{tag_id}/content"),
+    error = function(e) NULL
+  )
+
+  connect_pin_records(backend, items)
+}
+
+# Without a configured tag the listing shows every pin and defers the blockr
+# membership check to load time. Whether an item is a pin is already in the
+# bulk response, so no pin is inspected -- a non-blockr pin is filtered out
+# only when someone tries to open it.
+connect_list_all_pins <- function(backend) {
+
   items <- tryCatch(
     connect_api(backend, "GET /content"),
     error = function(e) NULL
   )
 
-  if (!length(items)) {
-    return(list())
-  }
+  connect_pin_records(backend, items)
+}
+
+connect_pin_records <- function(backend, items) {
 
   records <- list()
 
@@ -105,19 +131,29 @@ rack_list.pins_board_connect <- function(backend, tags = NULL, ...) {
       next
     }
 
-    membership <- connect_membership$lookup(backend, item)
-
-    if (isTRUE(membership$member)) {
-      records[[length(records) + 1L]] <- new_rack_record(
-        id = item$name,
-        name = connect_item_title(item),
-        user = membership$user,
-        saved = connect_item_saved(item)
-      )
-    }
+    records[[length(records) + 1L]] <- new_rack_record(
+      id = item$name,
+      name = connect_item_title(item),
+      user = connect_owner_cache$lookup(backend, item$owner_guid),
+      saved = connect_item_saved(item)
+    )
   }
 
-  records
+  connect_sort_records(records)
+}
+
+connect_sort_records <- function(records) {
+
+  if (length(records) < 2L) {
+    return(records)
+  }
+
+  key <- dbl_ply(
+    records,
+    function(r) if (is.null(r$saved)) NA_real_ else as.numeric(r$saved)
+  )
+
+  records[order(key, decreasing = TRUE, na.last = TRUE)]
 }
 
 connect_list_tagged <- function(backend, tags) {
@@ -163,47 +199,144 @@ connect_item_saved <- function(item) {
   connect_parse_time(stamp)
 }
 
-# Whether a pin is a blockr workflow -- and who owns it -- is intrinsic to the
-# pin, identical for every viewer, so the check memoizes safely in one
-# process-wide map keyed by slug: a pin is inspected once, the first time a
-# listing meets it, and the result is reused thereafter.
-connect_membership <- local({
+# A pin's owner is intrinsic to the content and identical for every viewer, so
+# the guid -> username resolution memoizes process-wide, keyed by server and
+# owner guid: an owner is resolved once however many of their pins are listed.
+connect_owner_cache <- local({
 
-  members <- list()
+  owners <- list()
 
   reset <- function() {
-    members <<- list()
+    owners <<- list()
   }
 
-  lookup <- function(backend, item) {
+  lookup <- function(backend, guid) {
 
-    slug <- item$name
-
-    if (is.null(members[[slug]])) {
-      members[[slug]] <<- connect_probe_membership(backend, item)
+    if (is.null(guid) || !nzchar(guid)) {
+      return(backend$account)
     }
 
-    members[[slug]]
+    key <- paste(backend$url, guid, sep = "\r")
+
+    if (is.null(owners[[key]])) {
+      owners[[key]] <<- list(user = connect_owner_name(backend, guid))
+    }
+
+    owners[[key]]$user
   }
 
   list(lookup = lookup, reset = reset)
 })
 
-connect_probe_membership <- function(backend, item) {
+connect_owner_name <- function(backend, guid) {
 
-  owner <- tryCatch(
-    connect_api(backend, "GET /users/{item$owner_guid}")$username,
+  name <- tryCatch(
+    connect_api(backend, "GET /users/{guid}")$username,
     error = function(e) NULL
   )
 
-  owner <- coal(owner, backend$account, fail_all = FALSE)
+  coal(name, backend$account, fail_all = FALSE)
+}
 
-  meta <- tryCatch(
-    pins::pin_meta(backend, paste0(owner, "/", item$name)),
+# Connect native tags -------------------------------------------------------
+
+connect_tag_id <- function(backend) {
+
+  spec <- blockr_option("session_connect_tag", NULL)
+
+  if (is.null(spec) || !is_string(spec) || !nzchar(spec)) {
+    return(NULL)
+  }
+
+  connect_resolve_tag(backend, spec)
+}
+
+connect_resolve_tag <- function(backend, spec) {
+
+  tags <- tryCatch(
+    connect_api(backend, "GET /tags"),
     error = function(e) NULL
   )
 
-  list(member = not_null(meta) && has_tags(meta), user = owner)
+  if (!length(tags)) {
+    return(NULL)
+  }
+
+  parts <- strsplit(spec, "/", fixed = TRUE)[[1L]]
+  parts <- parts[nzchar(parts)]
+
+  if (!length(parts)) {
+    return(NULL)
+  }
+
+  if (length(parts) > 1L) {
+    return(connect_walk_tag_path(tags, parts))
+  }
+
+  hits <- Filter(function(t) identical(t$name, parts[[1L]]), tags)
+
+  if (!length(hits)) {
+    return(NULL)
+  }
+
+  if (length(hits) > 1L) {
+    blockr_warn(
+      "Connect tag {parts[[1L]]} matches multiple tags; ",
+      "qualify it as \"Category/Name\".",
+      class = "connect_tag_ambiguous"
+    )
+  }
+
+  hits[[1L]]$id
+}
+
+connect_walk_tag_path <- function(tags, parts) {
+
+  parent <- NULL
+
+  for (part in parts) {
+
+    hit <- Find(
+      function(t) identical(t$name, part) && identical(t$parent_id, parent),
+      tags
+    )
+
+    if (is.null(hit)) {
+      return(NULL)
+    }
+
+    parent <- hit$id
+  }
+
+  parent
+}
+
+connect_add_tag <- function(backend, guid, tag_id) {
+  connect_api(
+    backend, "POST /content/{guid}/tags",
+    body = list(tag_id = tag_id)
+  )
+}
+
+connect_apply_tag <- function(backend, slug) {
+
+  tag_id <- connect_tag_id(backend)
+
+  if (is.null(tag_id)) {
+    return(invisible())
+  }
+
+  tryCatch(
+    connect_add_tag(backend, connect_content_find(backend, slug)$guid, tag_id),
+    error = function(e) {
+      blockr_warn(
+        "Could not apply Connect tag to {slug}: {conditionMessage(e)}",
+        class = "connect_tag_apply_failed"
+      )
+    }
+  )
+
+  invisible()
 }
 
 # rack_upload ---------------------------------------------------------------
@@ -238,6 +371,8 @@ rack_upload.pins_board_connect <- function(backend, path, id, name = NULL,
     metadata = metadata,
     tags = blockr_session_tags()
   )
+
+  connect_apply_tag(backend, slug)
 
   base <- new_rack_id_pins_connect(backend$account, slug)
 

--- a/R/server.R
+++ b/R/server.R
@@ -950,7 +950,14 @@ rack_loader <- function() {
     # double fetch is deliberate: a shared cache keyed by the URL handle would
     # leak across sessions when backend credentials are visitor-scoped, and a
     # session-scoped cache cannot span the GET -> WS boundary.
-    board_ser <- tryCatch(rack_load(id, backend), error = function(e) NULL)
+    board_ser <- tryCatch(
+      rack_load(id, backend),
+      rack_load_invalid_tags = function(e) {
+        refuse_incompatible_load(e, session)
+        NULL
+      },
+      error = function(e) NULL
+    )
 
     if (is.null(board_ser)) {
       return(clear_board(default))
@@ -966,6 +973,24 @@ rack_loader <- function() {
   }
 
   board_loader(resolve)
+}
+
+# A URL may point at a pin that is not a blockr workflow -- directly, or because
+# the unconfigured listing shows every pin. Loading one aborts before the
+# deserializer; warn the visitor at the WS phase (where a session exists) rather
+# than silently handing back a cleared board.
+refuse_incompatible_load <- function(cnd, session) {
+
+  if (is.null(session)) {
+    return(invisible())
+  }
+
+  notify(
+    conditionMessage(cnd),
+    type = "warning",
+    glue = FALSE,
+    session = session
+  )
 }
 
 navigate_to_board <- function(id, backend, session) {

--- a/man/user_pins_board.Rd
+++ b/man/user_pins_board.Rd
@@ -31,4 +31,9 @@ environment (\code{CONNECT_SERVER} and \code{CONNECT_API_KEY}), a board on the
 application's own account.
 \item Otherwise (e.g. local development, off Connect), \code{\link[pins:board_local]{pins::board_local()}}.
 }
+
+Set the \code{session_connect_tag} \code{\link[blockr.core:blockr_option]{blockr.core::blockr_option()}} to an existing
+Connect tag's name (or a \code{"Category/Name"} path) to have the workflow listing
+filter server-side by that native tag; saves then apply it. Unset, the
+listing returns every pin and checks blockr membership only on load.
 }

--- a/tests/testthat/test-connect-tag.R
+++ b/tests/testthat/test-connect-tag.R
@@ -1,0 +1,224 @@
+# session_connect_tag resolution --------------------------------------------
+
+test_that("connect_tag_id returns NULL when the option is unset", {
+
+  board <- mock_board_connect()
+
+  expect_null(connect_tag_id(board))
+})
+
+test_that("connect_tag_id resolves a bare tag name to its id", {
+
+  board <- mock_board_connect()
+  withr::local_options(blockr.session_connect_tag = "blockr")
+
+  local_mocked_bindings(
+    connect_api = function(board, route, ...) {
+      list(
+        list(id = 3, name = "other", parent_id = NULL),
+        list(id = 7, name = "blockr", parent_id = NULL)
+      )
+    }
+  )
+
+  expect_equal(connect_tag_id(board), 7)
+})
+
+test_that("connect_tag_id resolves a Category/Name path past a root decoy", {
+
+  board <- mock_board_connect()
+  withr::local_options(blockr.session_connect_tag = "Apps/blockr")
+
+  local_mocked_bindings(
+    connect_api = function(board, route, ...) {
+      list(
+        list(id = 1, name = "Apps", parent_id = NULL),
+        list(id = 2, name = "blockr", parent_id = 1),
+        list(id = 3, name = "blockr", parent_id = NULL)
+      )
+    }
+  )
+
+  expect_equal(connect_tag_id(board), 2)
+})
+
+test_that("connect_tag_id returns NULL for an unknown tag", {
+
+  board <- mock_board_connect()
+  withr::local_options(blockr.session_connect_tag = "nope")
+
+  local_mocked_bindings(
+    connect_api = function(board, route, ...) {
+      list(list(id = 1, name = "blockr", parent_id = NULL))
+    }
+  )
+
+  expect_null(connect_tag_id(board))
+})
+
+test_that("connect_tag_id warns and picks one when a bare name is ambiguous", {
+
+  board <- mock_board_connect()
+  withr::local_options(blockr.session_connect_tag = "blockr")
+
+  local_mocked_bindings(
+    connect_api = function(board, route, ...) {
+      list(
+        list(id = 1, name = "blockr", parent_id = 10),
+        list(id = 2, name = "blockr", parent_id = 20)
+      )
+    }
+  )
+
+  expect_warning(
+    id <- connect_tag_id(board),
+    class = "connect_tag_ambiguous"
+  )
+  expect_equal(id, 1)
+})
+
+# Configured listing --------------------------------------------------------
+
+test_that("rack_list filters server-side by tag when configured", {
+
+  board <- mock_board_connect()
+  connect_owner_cache$reset()
+  withr::defer(connect_owner_cache$reset())
+  withr::local_options(blockr.session_connect_tag = "blockr")
+
+  routes <- character()
+
+  local_mocked_bindings(
+    connect_api = function(board, route, ...) {
+      routes[[length(routes) + 1L]] <<- route
+      if (identical(route, "GET /tags")) {
+        return(list(list(id = 5, name = "blockr", parent_id = NULL)))
+      }
+      if (grepl("GET /tags/", route, fixed = TRUE)) {
+        return(
+          list(
+            list(name = "wf-a", title = "WF A", content_category = "pin",
+                 owner_guid = "g", last_deployed_time = "2020-01-01T00:00:00Z")
+          )
+        )
+      }
+      if (grepl("GET /users", route, fixed = TRUE)) {
+        return(list(username = "user_a"))
+      }
+      list()
+    }
+  )
+  local_mocked_bindings(
+    pin_meta = function(...) stop("must not probe a pin"),
+    pin_search = function(...) stop("must not pin_search"),
+    .package = "pins"
+  )
+
+  result <- rack_list(board)
+
+  expect_length(result, 1L)
+  expect_equal(result[[1L]]$id, "wf-a")
+  expect_equal(result[[1L]]$user, "user_a")
+  expect_true(any(grepl("GET /tags/", routes, fixed = TRUE)))
+})
+
+# Tag on upload -------------------------------------------------------------
+
+single_version <- function() {
+  data.frame(
+    version = "20200101T000000Z-aaaaa",
+    created = as.POSIXct("2020-01-01", tz = "UTC"),
+    hash = "abc123",
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("rack_upload applies the configured tag to the content", {
+
+  board <- mock_board_connect(account = "user_a")
+  withr::local_options(blockr.session_connect_tag = "blockr")
+
+  posted <- NULL
+
+  local_mocked_bindings(
+    pin_upload = function(...) invisible(),
+    pin_versions = function(...) single_version(),
+    pin_exists = function(...) FALSE,
+    .package = "pins"
+  )
+  local_mocked_bindings(
+    connect_content_find = function(board, name) list(guid = "guid-xyz"),
+    connect_api = function(board, route, ..., body = NULL) {
+      if (identical(route, "GET /tags")) {
+        return(list(list(id = 9, name = "blockr", parent_id = NULL)))
+      }
+      if (grepl("POST /content/.*/tags", route)) {
+        posted <<- list(route = route, body = body)
+      }
+      list()
+    }
+  )
+
+  rack_create(board, blockr_test_session, id = "wf", name = "WF")
+
+  expect_false(is.null(posted))
+  expect_equal(posted$body$tag_id, 9)
+})
+
+test_that("rack_upload does not tag when no tag is configured", {
+
+  board <- mock_board_connect(account = "user_a")
+
+  posted <- FALSE
+
+  local_mocked_bindings(
+    pin_upload = function(...) invisible(),
+    pin_versions = function(...) single_version(),
+    pin_exists = function(...) FALSE,
+    .package = "pins"
+  )
+  local_mocked_bindings(
+    connect_content_find = function(board, name) list(guid = "g"),
+    connect_api = function(board, route, ...) {
+      if (grepl("POST", route, fixed = TRUE)) {
+        posted <<- TRUE
+      }
+      list()
+    }
+  )
+
+  rack_create(board, blockr_test_session, id = "wf", name = "WF")
+
+  expect_false(posted)
+})
+
+test_that("a failed tag write does not fail the upload", {
+
+  board <- mock_board_connect(account = "user_a")
+  withr::local_options(blockr.session_connect_tag = "blockr")
+
+  local_mocked_bindings(
+    pin_upload = function(...) invisible(),
+    pin_versions = function(...) single_version(),
+    pin_exists = function(...) FALSE,
+    .package = "pins"
+  )
+  local_mocked_bindings(
+    connect_content_find = function(board, name) list(guid = "g"),
+    connect_api = function(board, route, ...) {
+      if (identical(route, "GET /tags")) {
+        return(list(list(id = 9, name = "blockr", parent_id = NULL)))
+      }
+      if (grepl("POST", route, fixed = TRUE)) {
+        stop("tag write failed")
+      }
+      list()
+    }
+  )
+
+  expect_warning(
+    result <- rack_create(board, blockr_test_session, id = "wf", name = "WF"),
+    class = "connect_tag_apply_failed"
+  )
+  expect_s3_class(result, "rack_id_pins_connect")
+})

--- a/tests/testthat/test-pins.R
+++ b/tests/testthat/test-pins.R
@@ -554,11 +554,13 @@ test_that("last_saved returns NULL for missing pin", {
 
 # Connect: rack_list --------------------------------------------------------
 
-test_that("rack_list on Connect lists members, probing each pin", {
+test_that("rack_list on Connect lists every pin without a per-pin probe", {
 
   board <- mock_board_connect()
-  connect_membership$reset()
-  withr::defer(connect_membership$reset())
+  connect_owner_cache$reset()
+  withr::defer(connect_owner_cache$reset())
+
+  probed <- FALSE
 
   local_mocked_bindings(
     connect_api = function(board, route, ...) {
@@ -567,37 +569,36 @@ test_that("rack_list on Connect lists members, probing each pin", {
       }
       list(
         list(name = "wf-a", title = "WF A", content_category = "pin",
-             owner_guid = "g", last_deployed_time = "2020-01-01T00:00:00Z"),
+             owner_guid = "g", last_deployed_time = "2020-02-01T00:00:00Z"),
         list(name = "plain-b", title = "Plain B", content_category = "pin",
-             owner_guid = "g")
+             owner_guid = "g", last_deployed_time = "2020-01-01T00:00:00Z")
       )
     }
   )
   local_mocked_bindings(
-    pin_meta = function(board, name, ...) {
-      if (grepl("wf-a", name, fixed = TRUE)) {
-        list(tags = "blockr-session")
-      } else {
-        list(tags = character())
-      }
+    pin_meta = function(...) {
+      probed <<- TRUE
+      stop("must not probe a pin at list time")
     },
     .package = "pins"
   )
 
   result <- rack_list(board)
 
-  expect_length(result, 1L)
+  expect_false(probed)
+  expect_length(result, 2L)
   expect_equal(result[[1L]]$id, "wf-a")
+  expect_equal(result[[2L]]$id, "plain-b")
   expect_equal(result[[1L]]$name, "WF A")
   expect_equal(result[[1L]]$user, "user_a")
-  expect_equal(result[[1L]]$saved, as.POSIXct("2020-01-01", tz = "UTC"))
+  expect_equal(result[[1L]]$saved, as.POSIXct("2020-02-01", tz = "UTC"))
 })
 
 test_that("rack_list on Connect skips non-pin content", {
 
   board <- mock_board_connect()
-  connect_membership$reset()
-  withr::defer(connect_membership$reset())
+  connect_owner_cache$reset()
+  withr::defer(connect_owner_cache$reset())
 
   local_mocked_bindings(
     connect_api = function(board, route, ...) {
@@ -611,10 +612,6 @@ test_that("rack_list on Connect skips non-pin content", {
       )
     }
   )
-  local_mocked_bindings(
-    pin_meta = function(board, name, ...) list(tags = "blockr-session"),
-    .package = "pins"
-  )
 
   result <- rack_list(board)
 
@@ -622,31 +619,26 @@ test_that("rack_list on Connect skips non-pin content", {
   expect_equal(result[[1L]]$id, "wf")
 })
 
-test_that("connect_membership probes a pin once and caches it", {
+test_that("connect_owner_cache resolves an owner once and caches it", {
 
   board <- mock_board_connect()
-  connect_membership$reset()
-  withr::defer(connect_membership$reset())
+  connect_owner_cache$reset()
+  withr::defer(connect_owner_cache$reset())
 
-  probes <- 0L
+  calls <- 0L
   local_mocked_bindings(
-    connect_api = function(board, route, ...) list(username = "user_a")
-  )
-  local_mocked_bindings(
-    pin_meta = function(board, name, ...) {
-      probes <<- probes + 1L
-      list(tags = "blockr-session")
-    },
-    .package = "pins"
+    connect_api = function(board, route, ...) {
+      calls <<- calls + 1L
+      list(username = "user_a")
+    }
   )
 
-  item <- list(name = "wf", owner_guid = "g")
-  first <- connect_membership$lookup(board, item)
-  connect_membership$lookup(board, item)
+  first <- connect_owner_cache$lookup(board, "guid-1")
+  second <- connect_owner_cache$lookup(board, "guid-1")
 
-  expect_true(first$member)
-  expect_equal(first$user, "user_a")
-  expect_equal(probes, 1L)
+  expect_equal(first, "user_a")
+  expect_equal(second, "user_a")
+  expect_equal(calls, 1L)
 })
 
 test_that("rack_list on Connect with tags uses the pin_search path", {

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -590,6 +590,38 @@ test_that("loader WS user-scopes via the configured user_pins_board (#70)", {
   expect_setequal(board_block_ids(loaded), "a")
 })
 
+test_that("loader refuses a non-blockr pin instead of blanking (#90)", {
+
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  upload_blockr_json(backend, list(x = 1), "not-blockr")
+
+  refused <- NULL
+  local_mocked_bindings(
+    refuse_incompatible_load = function(cnd, session) {
+      refused <<- conditionMessage(cnd)
+      invisible()
+    }
+  )
+
+  fake_session <- list(
+    request = list(),
+    clientData = list(url_search = "?id=not-blockr")
+  )
+
+  res <- rack_loader()$resolve(NULL, fake_session, new_board())
+
+  expect_s3_class(res, "board")
+  expect_length(board_block_ids(res), 0)
+  expect_false(is.null(refused))
+  expect_match(refused, "not compatible with blockr")
+})
+
+test_that("refuse_incompatible_load is a no-op without a session", {
+  expect_silent(refuse_incompatible_load(simpleCondition("x"), NULL))
+})
+
 test_that("version history marks the URL version as current (#19)", {
 
   backend <- pins::board_temp(versioned = TRUE)


### PR DESCRIPTION
## Summary

- Add a `session_connect_tag` option: set it to an existing Connect tag's name (or a `Category/Name` path) and the workflow listing filters server-side by that native tag via `GET /tags/{id}/content`, instead of downloading `pin_meta` for every pin. Uploads apply the tag best-effort; a failed tag write warns but never fails the save.
- With no tag configured the default listing now returns every pin from the bulk `GET /content` (no per-pin probe) and defers the blockr check to load. `rack_loader` then refuses a non-blockr pin with a warning notification rather than silently handing back a blank board.
- The O(pins) membership probe leaves the listing hot path; a light owner-guid → username memo stays, so shared workflows still resolve their owner and load.

## Two API shapes to confirm on the instance

The issue flagged these as "confirm at implementation" — I picked the best-supported options and kept each to one isolated helper. Tests mock at the `connect_api` boundary, so a wrong endpoint/field still passes CI; a one-line probe on the instance settles them:

- Listing uses `GET /v1/tags/{id}/content` (documented, returns a tag's content, no free-text query) rather than the issue's tentative `GET /v1/search/content?tag:`.
- Tagging posts `{"tag_id": <id>}` to `POST /v1/content/{guid}/tags`, with ids from `GET /v1/tags`.

## Deliberate behaviour change

The untagged (default) listing now shows all pins, not only blockr ones — the point being to drop the probe. On a Connect that mixes blockr and non-blockr pins this surfaces the latter in the list; opening one shows a "not compatible" notice instead of loading. Configuring the tag removes them from the listing again.

No bulk migration: workflows saved before the tag was configured get tagged on their next save, so they rejoin the filtered listing then rather than up front.

Fixes #90
