### PR TITLE
Window the Manage-workflows modal table

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -210,19 +210,9 @@ manage_project_server <- function(id, board, ...) {
         250
       )
 
-      filtered_workflows <- reactive({
-
-        query <- tolower(trimws(workflow_query()))
-
-        if (!nzchar(query)) {
-          return(all_workflows())
-        }
-
-        Filter(
-          function(wf) grepl(query, tolower(coal(wf$name, "")), fixed = TRUE),
-          all_workflows()
-        )
-      })
+      filtered_workflows <- reactive(
+        search_workflows(all_workflows(), workflow_query())
+      )
 
       workflow_batch <- 10L
       n_shown <- reactiveVal(workflow_batch)
@@ -304,21 +294,188 @@ manage_project_server <- function(id, board, ...) {
         )
       )
 
-      # VIEW ALL WORKFLOWS modal
+      # MANAGE WORKFLOWS modal: a server-side window of the filtered list, with
+      # selection tracked server-side so select-all and delete act over the
+      # whole filtered set rather than the loaded rows.
+
+      modal_query <- debounce(
+        reactive(coal(input$modal_workflow_filter, "")),
+        250
+      )
+
+      modal_filtered <- reactive(
+        search_workflows(all_workflows(), modal_query())
+      )
+
+      modal_n_shown <- reactiveVal(workflow_batch)
+      modal_selection <- reactiveVal(character())
+      modal_open <- reactiveVal(FALSE)
+
       observeEvent(
         input$view_all_workflows,
         {
-          workflows <- tryCatch(
-            rack_list(backend),
-            error = function(e) list()
-          )
-
-          if (length(workflows) == 0L) {
+          if (length(all_workflows()) == 0L) {
             notify("No saved workflows", type = "message")
             return()
           }
 
-          show_workflows_modal(workflows, backend, session)
+          modal_n_shown(workflow_batch)
+          modal_selection(character())
+          modal_open(TRUE)
+
+          show_workflows_modal(session)
+        }
+      )
+
+      observeEvent(input$modal_closed, modal_open(FALSE))
+
+      observeEvent(
+        modal_query(),
+        {
+          modal_n_shown(workflow_batch)
+          modal_selection(character())
+        }
+      )
+
+      observeEvent(
+        input$modal_load_more,
+        {
+          total <- length(modal_filtered())
+          modal_n_shown(min(modal_n_shown() + workflow_batch, total))
+        }
+      )
+
+      observeEvent(
+        input$modal_toggle,
+        {
+          tog <- input$modal_toggle
+
+          if (isTRUE(tog$checked)) {
+            modal_selection(union(modal_selection(), tog$id))
+          } else {
+            modal_selection(setdiff(modal_selection(), tog$id))
+          }
+        }
+      )
+
+      observeEvent(
+        input$modal_select_all,
+        {
+          if (isTRUE(input$modal_select_all$checked)) {
+            modal_selection(chr_xtr(modal_filtered(), "id"))
+          } else {
+            modal_selection(character())
+          }
+        }
+      )
+
+      observe(
+        {
+          if (!isTRUE(modal_open())) {
+            return()
+          }
+
+          session$sendCustomMessage(
+            "blockr-modal-selection",
+            list(
+              count = length(
+                modal_selected_records(modal_selection(), all_workflows())
+              ),
+              total = length(modal_filtered())
+            )
+          )
+        }
+      )
+
+      observeEvent(
+        input$modal_delete,
+        {
+          records <- modal_selected_records(modal_selection(), all_workflows())
+          req(length(records) > 0L)
+
+          deleted <- delete_rack_records(records, backend, session)
+
+          if (deleted > 0L) {
+            notify(paste("Deleted", deleted, "workflow(s)"), type = "message")
+            modal_selection(character())
+            refresh_trigger(refresh_trigger() + 1)
+          }
+        }
+      )
+
+      output$modal_workflow_count <- renderText(
+        {
+          total <- length(all_workflows())
+
+          if (total == 0L) {
+            return("")
+          }
+
+          if (nzchar(trimws(modal_query()))) {
+            paste0(length(modal_filtered()), " / ", total)
+          } else {
+            as.character(total)
+          }
+        }
+      )
+
+      output$workflows_modal_rows <- renderUI(
+        {
+          if (length(all_workflows()) == 0L) {
+            return(modal_message_row("No saved workflows"))
+          }
+
+          matches <- modal_filtered()
+
+          if (length(matches) == 0L) {
+            return(modal_message_row("No workflows match your search"))
+          }
+
+          shown <- matches[seq_len(min(modal_n_shown(), length(matches)))]
+
+          tagList(
+            lapply(
+              shown, workflow_modal_row, isolate(modal_selection()),
+              backend, session$ns
+            ),
+            if (length(matches) > length(shown)) {
+              modal_sentinel_row(session$ns("modal_load_more"))
+            }
+          )
+        }
+      )
+
+      output$download_selected <- downloadHandler(
+        filename = function() {
+          records <- modal_selected_records(modal_selection(), all_workflows())
+          if (length(records) == 1L) {
+            paste0(records[[1L]]$name, ".json")
+          } else {
+            "workflows.zip"
+          }
+        },
+        content = function(file) {
+          records <- modal_selected_records(modal_selection(), all_workflows())
+          req(length(records) > 0L)
+
+          sel <- lapply(
+            records,
+            function(wf) {
+              list(id = wf$id, name = wf$name, user = coal(wf$user, ""))
+            }
+          )
+
+          tryCatch(
+            file.copy(prepare_download(sel, backend), file),
+            error = function(e) {
+              notify(
+                paste("Download failed:", conditionMessage(e)),
+                type = "error",
+                glue = FALSE,
+                session = session
+              )
+            }
+          )
         }
       )
 
@@ -326,32 +483,12 @@ manage_project_server <- function(id, board, ...) {
         input$delete_workflows,
         {
           req(input$delete_workflows)
-          sel <- normalize_js_input(input$delete_workflows)
-          deleted <- 0
-          for (wf in sel) {
-            id <- rack_id_from_input(backend, wf)
-            res <- tryCatch(
-              {
-                rack_purge(id, backend)
-                deleted <- deleted + 1
-                TRUE
-              },
-              error = function(e) {
-                notify(
-                  paste("Failed to delete:", coal(wf$name, wf$id,
-                                                  fail_all = FALSE)),
-                  type = "error"
-                )
-                FALSE
-              }
-            )
-          }
+
+          records <- normalize_js_input(input$delete_workflows)
+          deleted <- delete_rack_records(records, backend, session)
+
           if (deleted > 0) {
-            notify(
-              paste("Deleted", deleted, "workflow(s)"),
-              type = "message"
-            )
-            removeModal()
+            notify(paste("Deleted", deleted, "workflow(s)"), type = "message")
             refresh_trigger(refresh_trigger() + 1)
           }
         }
@@ -1033,6 +1170,20 @@ refuse_incompatible_load <- function(cnd, session) {
   )
 }
 
+search_workflows <- function(workflows, query) {
+
+  query <- tolower(trimws(query))
+
+  if (!nzchar(query)) {
+    return(workflows)
+  }
+
+  Filter(
+    function(wf) grepl(query, tolower(coal(wf$name, "")), fixed = TRUE),
+    workflows
+  )
+}
+
 workflow_item <- function(wf, backend, ns) {
 
   tags$div(
@@ -1096,105 +1247,138 @@ hide_modal_js <- function(modal_id) {
   )
 }
 
-show_workflows_modal <- function(workflows, backend, session) {
+modal_selected_records <- function(ids, workflows) {
+  Filter(function(wf) wf$id %in% ids, workflows)
+}
 
-  rows <- lapply(
-    seq_along(workflows),
-    function(i) {
-      wf <- workflows[[i]]
-      wf_time <- record_time_ago(wf)
-      tags$tr(
-        class = "blockr-workflow-row",
-        `data-name` = tolower(wf$name),
-        `data-user` = coal(wf$user, ""),
-        tags$td(
-          class = "blockr-wf-checkbox",
-          tags$input(
-            type = "checkbox",
-            class = "blockr-wf-select",
-            `data-id` = wf$id,
-            `data-name` = wf$name,
-            `data-user` = coal(wf$user, "")
-          )
+delete_rack_records <- function(records, backend, session) {
+
+  deleted <- 0L
+
+  for (wf in records) {
+    ok <- tryCatch(
+      {
+        rack_purge(rack_id_from_input(backend, wf), backend)
+        TRUE
+      },
+      error = function(e) {
+        notify(
+          paste("Failed to delete:", coal(wf$name, wf$id, fail_all = FALSE)),
+          type = "error",
+          session = session
+        )
+        FALSE
+      }
+    )
+
+    if (ok) {
+      deleted <- deleted + 1L
+    }
+  }
+
+  deleted
+}
+
+workflow_modal_row <- function(wf, selected, backend, ns) {
+
+  tags$tr(
+    class = "blockr-workflow-row",
+    tags$td(
+      class = "blockr-wf-checkbox",
+      tags$input(
+        type = "checkbox",
+        class = "blockr-wf-select",
+        `data-id` = wf$id,
+        checked = if (wf$id %in% selected) "checked"
+      )
+    ),
+    tags$td(class = "blockr-wf-name", wf$name),
+    tags$td(class = "blockr-wf-time", record_time_ago(wf)),
+    tags$td(
+      class = "blockr-wf-action",
+      tags$div(
+        class = "blockr-wf-row-actions",
+        tags$button(
+          class = "btn btn-sm btn-primary",
+          onclick = paste0(
+            shiny_input_obj_js(
+              ns("load_workflow"),
+              id = wf$id,
+              user = coal(wf$user, "")
+            ),
+            "\n",
+            hide_modal_js(ns("workflows_modal"))
+          ),
+          "Load"
         ),
-        tags$td(class = "blockr-wf-name", wf$name),
-        tags$td(class = "blockr-wf-time", wf_time),
-        tags$td(
-          class = "blockr-wf-action",
-          tags$div(
-            class = "blockr-wf-row-actions",
-            tags$button(
-              class = "btn btn-sm btn-primary",
-              onclick = paste0(
-                shiny_input_obj_js(
-                  session$ns("load_workflow"),
-                  id = wf$id,
-                  user = coal(wf$user, "")
-                ),
-                "\n",
-                hide_modal_js(session$ns("workflows_modal"))
-              ),
-              "Load"
-            ),
-            tags$a(
-              class = "btn btn-sm btn-outline-secondary",
-              href = board_query_string(wf, backend),
-              target = "_blank",
-              bsicons::bs_icon(
-                "box-arrow-up-right",
-                size = "0.85em"
-              )
-            ),
-            tags$button(
-              class = "btn btn-sm btn-outline-primary blockr-wf-row-btn",
-              title = "Download",
-              onclick = sprintf(
-                "Shiny.setInputValue('%s', [{id: '%s', name: '%s',
-                  user: '%s'}], {priority: 'event'});
-                  setTimeout(function() {
-                    document.getElementById('%s').click();
-                  }, 100);",
-                session$ns("wf_selection"),
-                wf$id,
-                wf$name,
-                coal(wf$user, ""),
-                session$ns("download_workflows")
-              ),
-              bsicons::bs_icon("download")
-            ),
-            tags$button(
-              class = "btn btn-sm btn-outline-danger blockr-wf-row-btn",
-              title = "Delete",
-              onclick = sprintf(
-                "if (confirm('Delete %s?')) {
-                  Shiny.setInputValue('%s',
-                    [{id: '%s', name: '%s', user: '%s'}],
-                    {priority: 'event'});
-                }",
-                wf$name,
-                session$ns("delete_workflows"),
-                wf$id,
-                wf$name,
-                coal(wf$user, "")
-              ),
-              bsicons::bs_icon("trash")
-            )
-          )
+        tags$a(
+          class = "btn btn-sm btn-outline-secondary",
+          href = board_query_string(wf, backend),
+          target = "_blank",
+          bsicons::bs_icon("box-arrow-up-right", size = "0.85em")
+        ),
+        tags$button(
+          class = "btn btn-sm btn-outline-primary blockr-wf-row-btn",
+          title = "Download",
+          onclick = sprintf(
+            "Shiny.setInputValue('%s', [{id: '%s', name: '%s',
+              user: '%s'}], {priority: 'event'});
+              setTimeout(function() {
+                document.getElementById('%s').click();
+              }, 100);",
+            ns("wf_selection"),
+            wf$id,
+            wf$name,
+            coal(wf$user, ""),
+            ns("download_workflows")
+          ),
+          bsicons::bs_icon("download")
+        ),
+        tags$button(
+          class = "btn btn-sm btn-outline-danger blockr-wf-row-btn",
+          title = "Delete",
+          onclick = sprintf(
+            "if (confirm('Delete %s?')) {
+              Shiny.setInputValue('%s',
+                [{id: '%s', name: '%s', user: '%s'}],
+                {priority: 'event'});
+            }",
+            wf$name,
+            ns("delete_workflows"),
+            wf$id,
+            wf$name,
+            coal(wf$user, "")
+          ),
+          bsicons::bs_icon("trash")
         )
       )
-    }
+    )
   )
+}
 
-  modal_js <- modal_table_js(
-    select_all_id = session$ns("select_all"),
-    checkbox_class = "blockr-wf-select",
-    delete_btn_id = session$ns("delete_workflows_btn"),
-    delete_input_id = session$ns("delete_workflows"),
-    item_type = "workflow",
-    search_id = session$ns("workflow_search"),
-    download_btn_id = session$ns("download_workflows_btn"),
-    selection_input_id = session$ns("wf_selection")
+modal_sentinel_row <- function(input_id) {
+  tags$tr(
+    class = "blockr-wf-modal-sentinel",
+    `data-input-id` = input_id,
+    tags$td(
+      colspan = "4",
+      tags$div(
+        class = "blockr-wf-modal-loader",
+        tags$div(class = "blockr-workflow-spinner")
+      )
+    )
   )
+}
+
+modal_message_row <- function(text) {
+  tags$tr(
+    tags$td(class = "blockr-wf-modal-message", colspan = "4", text)
+  )
+}
+
+show_workflows_modal <- function(session) {
+
+  ns <- session$ns
 
   showModal(
     modalDialog(
@@ -1203,23 +1387,31 @@ show_workflows_modal <- function(workflows, backend, session) {
       easyClose = TRUE,
       footer = NULL,
       tags$div(
-        id = session$ns("workflows_modal"),
-        class = "blockr-workflows-modal",
+        id = ns("workflows_modal"),
+        class = "blockr-workflows-modal blockr-wf-manage-modal",
+        `data-toggle-input` = ns("modal_toggle"),
+        `data-select-all-input` = ns("modal_select_all"),
+        `data-filter-input` = ns("modal_workflow_filter"),
+        `data-delete-input` = ns("modal_delete"),
+        `data-closed-input` = ns("modal_closed"),
+        `data-delete-btn` = ns("delete_selected_btn"),
+        `data-download-wrap` = ns("download_selected_wrap"),
         tags$div(
           class = "blockr-wf-header",
-          tags$h5("All Workflows"),
+          tags$h5("Manage Workflows"),
           tags$div(
             class = "blockr-wf-header-actions",
             tags$button(
-              id = session$ns("delete_workflows_btn"),
+              id = ns("delete_selected_btn"),
               class = "btn btn-sm btn-outline-danger",
               style = "display: none;",
               "Delete"
             ),
             tags$div(
-              id = session$ns("download_workflows_btn"),
+              id = ns("download_selected_wrap"),
+              style = "visibility: hidden; position: absolute;",
               downloadButton(
-                session$ns("download_workflows"),
+                ns("download_selected"),
                 label = "Download",
                 class = "btn-sm btn-primary"
               )
@@ -1227,7 +1419,7 @@ show_workflows_modal <- function(workflows, backend, session) {
             tags$div(
               class = "blockr-wf-upload-compact",
               fileInput(
-                session$ns("upload_file"),
+                ns("upload_file"),
                 label = NULL,
                 accept = ".json",
                 multiple = TRUE,
@@ -1235,11 +1427,23 @@ show_workflows_modal <- function(workflows, backend, session) {
                 placeholder = NULL
               )
             ),
-            tags$input(
-              type = "text",
-              id = session$ns("workflow_search"),
-              class = "blockr-wf-search",
-              placeholder = "Search workflows..."
+            tags$div(
+              class = "blockr-wf-search-wrap",
+              tags$input(
+                type = "text",
+                id = ns("modal_workflow_filter"),
+                class = "blockr-wf-search",
+                placeholder = "Search workflows...",
+                autocomplete = "off",
+                oninput = sprintf(
+                  "Shiny.setInputValue('%s', this.value, {priority: 'event'})",
+                  ns("modal_workflow_filter")
+                )
+              ),
+              tags$span(
+                class = "blockr-wf-count",
+                textOutput(ns("modal_workflow_count"), inline = TRUE)
+              )
             )
           )
         ),
@@ -1253,7 +1457,7 @@ show_workflows_modal <- function(workflows, backend, session) {
                   class = "blockr-wf-checkbox",
                   tags$input(
                     type = "checkbox",
-                    id = session$ns("select_all")
+                    class = "blockr-wf-select-all"
                   )
                 ),
                 tags$th("Name"),
@@ -1261,10 +1465,13 @@ show_workflows_modal <- function(workflows, backend, session) {
                 tags$th("")
               )
             ),
-            tags$tbody(rows)
+            uiOutput(ns("workflows_modal_rows"), container = tags$tbody)
           )
         ),
-        tags$script(HTML(modal_js))
+        tags$div(
+          style = "display: none;",
+          downloadButton(ns("download_workflows"), label = NULL)
+        )
       )
     )
   )
@@ -1384,7 +1591,7 @@ show_versions_modal <- function(id, versions, session, backend, name = NULL) {
     }
   )
 
-  modal_js <- modal_table_js(
+  modal_js <- versions_modal_js(
     select_all_id = session$ns("select_all_versions"),
     checkbox_class = "blockr-version-select",
     delete_btn_id = session$ns("delete_versions_btn"),
@@ -1452,27 +1659,10 @@ show_versions_modal <- function(id, versions, session, backend, name = NULL) {
   )
 }
 
-modal_table_js <- function(select_all_id, checkbox_class, delete_btn_id,
-                           delete_input_id, item_type = "item",
-                           search_id = NULL, has_disabled = FALSE,
-                           download_btn_id = NULL,
-                           selection_input_id = NULL) {
-
-  if (!is.null(search_id)) {
-    search_block <- sprintf(
-      "document.getElementById('%s').addEventListener('input', function(e) {
-        var filter = e.target.value.toLowerCase();
-        var rows = document.querySelectorAll('.blockr-workflow-row');
-        rows.forEach(function(row) {
-          var name = row.getAttribute('data-name');
-          row.style.display = name.includes(filter) ? '' : 'none';
-        });
-      });",
-      search_id
-    )
-  } else {
-    search_block <- ""
-  }
+versions_modal_js <- function(select_all_id, checkbox_class, delete_btn_id,
+                              delete_input_id, item_type = "item",
+                              has_disabled = FALSE, download_btn_id = NULL,
+                              selection_input_id = NULL) {
 
   if (has_disabled) {
     disabled_filter <- ":not(:disabled)"
@@ -1519,8 +1709,7 @@ modal_table_js <- function(select_all_id, checkbox_class, delete_btn_id,
   }
 
   sprintf(
-    "%s
-    document.getElementById('%s').addEventListener('change', function(e) {
+    "document.getElementById('%s').addEventListener('change', function(e) {
       var checkboxes = document.querySelectorAll('.%s%s');
       checkboxes.forEach(function(cb) { cb.checked = e.target.checked });
       updateDeleteBtn();
@@ -1558,7 +1747,6 @@ modal_table_js <- function(select_all_id, checkbox_class, delete_btn_id,
     });
 
     updateDeleteBtn();",
-    search_block,
     select_all_id,
     checkbox_class,
     disabled_filter,

--- a/inst/assets/css/project-navbar.css
+++ b/inst/assets/css/project-navbar.css
@@ -616,9 +616,35 @@
   color: #9ca3af;
 }
 
+.blockr-wf-search-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.blockr-wf-count {
+  font-size: 0.8125rem;
+  color: #6b7280;
+  min-width: 1.5em;
+}
+
 .blockr-wf-table-container {
   max-height: 400px;
   overflow-y: auto;
+}
+
+.blockr-wf-modal-message {
+  padding: 24px 16px;
+  text-align: center;
+  color: #6b7280;
+  font-size: 0.875rem;
+}
+
+.blockr-wf-modal-loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
 }
 
 .blockr-wf-table {

--- a/inst/assets/js/project-navbar.js
+++ b/inst/assets/js/project-navbar.js
@@ -120,3 +120,135 @@ document.addEventListener('shown.bs.dropdown', function(event) {
   input.focus();
   input.select();
 });
+
+// --- Manage-workflows modal: server-windowed table --------------------------
+// The modal renders a server-side window of the (server-filtered) list plus a
+// sentinel row; scrolling it into view asks for the next batch. Selection is
+// authoritative on the server, so select-all and delete act over the whole
+// filtered set rather than only the loaded rows: each checkbox reports its
+// toggle, select-all reports one event, and the server pushes back the count.
+
+var blockrModalSentinelObserver = null;
+
+function blockrArmModalSentinel(modal) {
+  if (blockrModalSentinelObserver) blockrModalSentinelObserver.disconnect();
+
+  var sentinel = modal.querySelector('.blockr-wf-modal-sentinel');
+  if (!sentinel) return;
+
+  blockrModalSentinelObserver = new IntersectionObserver(
+    function(entries) {
+      entries.forEach(function(entry) {
+        if (entry.isIntersecting) {
+          Shiny.setInputValue(
+            sentinel.getAttribute('data-input-id'),
+            Date.now(),
+            { priority: 'event' }
+          );
+        }
+      });
+    },
+    {
+      root: modal.querySelector('.blockr-wf-table-container'),
+      rootMargin: '120px'
+    }
+  );
+
+  blockrModalSentinelObserver.observe(sentinel);
+}
+
+function blockrInitWorkflowsModal(root) {
+  var modal = root.classList && root.classList.contains('blockr-wf-manage-modal')
+    ? root
+    : root.querySelector('.blockr-wf-manage-modal');
+  if (!modal || modal.dataset.blockrInit) return;
+  modal.dataset.blockrInit = '1';
+
+  var toggleInput = modal.getAttribute('data-toggle-input');
+  var selectAllInput = modal.getAttribute('data-select-all-input');
+  var deleteInput = modal.getAttribute('data-delete-input');
+  var container = modal.querySelector('.blockr-wf-table-container');
+
+  // Clear any server-side filter left over from a previous open.
+  Shiny.setInputValue(
+    modal.getAttribute('data-filter-input'), '', { priority: 'event' }
+  );
+
+  // Delegated so rows materialized on scroll are covered too.
+  container.addEventListener('change', function(e) {
+    var cb = e.target;
+    if (!cb.classList.contains('blockr-wf-select')) return;
+    Shiny.setInputValue(
+      toggleInput,
+      { id: cb.getAttribute('data-id'), checked: cb.checked, nonce: Date.now() },
+      { priority: 'event' }
+    );
+  });
+
+  var selectAll = modal.querySelector('.blockr-wf-select-all');
+  selectAll.addEventListener('change', function(e) {
+    modal.querySelectorAll('.blockr-wf-select').forEach(function(cb) {
+      cb.checked = e.target.checked;
+    });
+    Shiny.setInputValue(
+      selectAllInput,
+      { checked: e.target.checked, nonce: Date.now() },
+      { priority: 'event' }
+    );
+  });
+
+  var delBtn = document.getElementById(modal.getAttribute('data-delete-btn'));
+  delBtn.addEventListener('click', function() {
+    var n = parseInt(modal.dataset.selCount || '0', 10);
+    if (n > 0 && confirm('Delete ' + n + ' workflow(s)?')) {
+      Shiny.setInputValue(deleteInput, Date.now(), { priority: 'event' });
+    }
+  });
+
+  blockrArmModalSentinel(modal);
+  new MutationObserver(function() {
+    blockrArmModalSentinel(modal);
+  }).observe(container, { childList: true, subtree: true });
+}
+
+// The server pushes the authoritative selection count on every change; reflect
+// it in the Delete/Download buttons and the select-all box.
+Shiny.addCustomMessageHandler('blockr-modal-selection', function(msg) {
+  var modal = document.querySelector('.blockr-wf-manage-modal');
+  if (!modal) return;
+
+  modal.dataset.selCount = msg.count;
+
+  var delBtn = document.getElementById(modal.getAttribute('data-delete-btn'));
+  if (delBtn) {
+    delBtn.style.display = msg.count > 0 ? '' : 'none';
+    delBtn.textContent = 'Delete (' + msg.count + ')';
+  }
+
+  var dlWrap = document.getElementById(modal.getAttribute('data-download-wrap'));
+  if (dlWrap) {
+    dlWrap.style.visibility = msg.count > 0 ? 'visible' : 'hidden';
+    dlWrap.style.position = msg.count > 0 ? '' : 'absolute';
+    var dlLink = dlWrap.querySelector('a');
+    if (dlLink) dlLink.textContent = 'Download (' + msg.count + ')';
+  }
+
+  var selectAll = modal.querySelector('.blockr-wf-select-all');
+  if (selectAll) {
+    selectAll.checked = msg.count > 0 && msg.count === msg.total;
+    selectAll.indeterminate = msg.count > 0 && msg.count < msg.total;
+  }
+});
+
+document.addEventListener('shown.bs.modal', function(event) {
+  blockrInitWorkflowsModal(event.target);
+});
+
+document.addEventListener('hidden.bs.modal', function(event) {
+  var modal = event.target.querySelector('.blockr-wf-manage-modal');
+  if (modal) {
+    Shiny.setInputValue(
+      modal.getAttribute('data-closed-input'), Date.now(), { priority: 'event' }
+    );
+  }
+});

--- a/tests/testthat/test-menu.R
+++ b/tests/testthat/test-menu.R
@@ -76,3 +76,211 @@ test_that("workflow menu windows results and filters server-side", {
     )
   )
 })
+
+test_that("manage-workflows modal windows results and filters server-side", {
+
+  withr::local_options(
+    blockr.session_mgmt_backend = pins::board_temp(versioned = TRUE)
+  )
+
+  records <- lapply(
+    seq_len(25L),
+    function(i) {
+      new_rack_record(
+        id = sprintf("wf-%02d", i),
+        name = if (i <= 5L) sprintf("alpha-%d", i) else sprintf("beta-%d", i),
+        user = "tester",
+        saved = Sys.time()
+      )
+    }
+  )
+
+  n_rows <- function(out) {
+    html <- paste(as.character(out), collapse = "")
+    hits <- gregexpr("class=\"blockr-workflow-row\"", html, fixed = TRUE)[[1L]]
+    if (length(hits) == 1L && hits == -1L) 0L else length(hits)
+  }
+
+  local_mocked_bindings(
+    rack_list = function(backend, ...) records,
+    board_query_string = function(x, backend, ...) "?board=test",
+    .package = "blockr.session"
+  )
+
+  testServer(
+    manage_project_server,
+    {
+      session$flushReact()
+
+      expect_length(modal_filtered(), 25L)
+      expect_identical(modal_n_shown(), 10L)
+      expect_identical(n_rows(output$workflows_modal_rows), 10L)
+      expect_match(
+        paste(as.character(output$workflows_modal_rows), collapse = ""),
+        "blockr-wf-modal-sentinel"
+      )
+
+      session$setInputs(modal_load_more = 1)
+      session$flushReact()
+
+      expect_identical(modal_n_shown(), 20L)
+      expect_identical(n_rows(output$workflows_modal_rows), 20L)
+
+      session$setInputs(modal_workflow_filter = "alpha")
+      session$elapse(300)
+      session$flushReact()
+
+      expect_length(modal_filtered(), 5L)
+      expect_identical(modal_n_shown(), 10L)
+      expect_identical(n_rows(output$workflows_modal_rows), 5L)
+      expect_identical(output$modal_workflow_count, "5 / 25")
+      expect_no_match(
+        paste(as.character(output$workflows_modal_rows), collapse = ""),
+        "blockr-wf-modal-sentinel"
+      )
+
+      session$setInputs(modal_workflow_filter = "zzz")
+      session$elapse(300)
+      session$flushReact()
+
+      expect_length(modal_filtered(), 0L)
+      expect_match(
+        paste(as.character(output$workflows_modal_rows), collapse = ""),
+        "No workflows match your search"
+      )
+    },
+    args = list(
+      board = reactiveValues(board = new_board(), board_id = "modal-test")
+    )
+  )
+})
+
+test_that("modal select-all and delete act over the whole filtered set (#92)", {
+
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  for (i in seq_len(12L)) {
+    rack_create(
+      backend, list(blocks = list()),
+      id = sprintf("wf-%02d", i), name = sprintf("wf-%02d", i)
+    )
+  }
+
+  testServer(
+    manage_project_server,
+    {
+      session$flushReact()
+
+      expect_length(modal_filtered(), 12L)
+      expect_identical(modal_n_shown(), 10L)
+
+      session$setInputs(modal_select_all = list(checked = TRUE, nonce = 1))
+      session$flushReact()
+
+      # every filtered id is selected, including the two beyond the window
+      expect_length(modal_selection(), 12L)
+
+      session$setInputs(modal_delete = 1)
+      session$flushReact()
+
+      expect_length(pins::pin_list(backend), 0L)
+    },
+    args = list(
+      board = reactiveValues(board = new_board(), board_id = "del-all")
+    )
+  )
+})
+
+test_that("modal delete removes only the filtered selection (#92)", {
+
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  for (i in seq_len(6L)) {
+    nm <- if (i <= 3L) sprintf("alpha-%d", i) else sprintf("beta-%d", i)
+    rack_create(backend, list(blocks = list()), id = nm, name = nm)
+  }
+
+  testServer(
+    manage_project_server,
+    {
+      session$setInputs(modal_workflow_filter = "alpha")
+      session$elapse(300)
+      session$flushReact()
+
+      expect_length(modal_filtered(), 3L)
+
+      session$setInputs(modal_select_all = list(checked = TRUE, nonce = 1))
+      session$flushReact()
+
+      expect_length(modal_selection(), 3L)
+
+      session$setInputs(modal_delete = 1)
+      session$flushReact()
+
+      remaining <- pins::pin_list(backend)
+      expect_length(remaining, 3L)
+      expect_true(all(grepl("^beta", remaining)))
+    },
+    args = list(
+      board = reactiveValues(board = new_board(), board_id = "del-flt")
+    )
+  )
+})
+
+test_that("modal_toggle updates the server-side selection", {
+
+  withr::local_options(
+    blockr.session_mgmt_backend = pins::board_temp(versioned = TRUE)
+  )
+
+  records <- lapply(
+    seq_len(3L),
+    function(i) {
+      new_rack_record(
+        id = sprintf("wf-%d", i), name = sprintf("wf-%d", i),
+        user = "tester", saved = Sys.time()
+      )
+    }
+  )
+
+  local_mocked_bindings(
+    rack_list = function(backend, ...) records,
+    .package = "blockr.session"
+  )
+
+  testServer(
+    manage_project_server,
+    {
+      session$flushReact()
+
+      session$setInputs(
+        modal_toggle = list(id = "wf-2", checked = TRUE, nonce = 1)
+      )
+      session$flushReact()
+      expect_identical(modal_selection(), "wf-2")
+
+      session$setInputs(
+        modal_toggle = list(id = "wf-1", checked = TRUE, nonce = 2)
+      )
+      session$flushReact()
+      expect_setequal(modal_selection(), c("wf-1", "wf-2"))
+
+      session$setInputs(
+        modal_toggle = list(id = "wf-2", checked = FALSE, nonce = 3)
+      )
+      session$flushReact()
+      expect_identical(modal_selection(), "wf-1")
+
+      # switching the filter clears the selection so we never delete unseen rows
+      session$setInputs(modal_workflow_filter = "wf-3")
+      session$elapse(300)
+      session$flushReact()
+      expect_length(modal_selection(), 0L)
+    },
+    args = list(
+      board = reactiveValues(board = new_board(), board_id = "toggle-test")
+    )
+  )
+})


### PR DESCRIPTION
## Summary

- The Manage-workflows modal painted every workflow row and filtered in the browser — the same paint-all exposure #80 removed from the dropdown, on a heavier table. It now renders a server-side window, filters server-side, and materializes more on scroll, reusing the dropdown's `all_workflows` / window / sentinel pattern.
- Selection is tracked **server-side** (`modal_selection`), so select-all and delete act over the whole server-side filtered set rather than only the checkboxes currently in the DOM — the select-all-across-unloaded-rows requirement. Row toggles and select-all report to the server; the header Delete/Download counts come back over a custom message.
- The shared `modal_table_js` drove the version-history modal too, so it's decoupled: renamed `versions_modal_js` and stripped of the workflow-only client-side search. Versions are few per workflow, so that modal stays a simple non-windowed table.
- The modal keeps its full role — every per-row action (load, open, download, delete) is preserved, and per-row plus bulk delete now re-render it in place instead of closing it.

Fixes #92
