### PR TITLE
Show read-only rack ID in navbar; choose it on save

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -338,7 +338,19 @@ manage_project_server <- function(id, board, ...) {
         save_status()
       )
 
-      output$rack_id <- renderText(current_rack_id())
+      output$rack_id_area <- renderUI({
+
+        req(current_id())
+
+        tagList(
+          tagAppendAttributes(
+            tags$span(current_rack_id()),
+            class = "blockr-navbar-title blockr-navbar-rack-id",
+            title = "Workflow ID"
+          ),
+          tags$span(class = "blockr-navbar-divider")
+        )
+      })
 
       observeEvent(
         input$load_workflow,

--- a/R/server.R
+++ b/R/server.R
@@ -352,6 +352,10 @@ manage_project_server <- function(id, board, ...) {
         )
       })
 
+      output$save_controls <- renderUI(
+        save_controls(session$ns, saved = not_null(current_id()))
+      )
+
       observeEvent(
         input$load_workflow,
         navigate_to_board(
@@ -1274,6 +1278,54 @@ navigate_to_board <- function(id, backend, session) {
   )
 
   session$reload()
+}
+
+save_controls <- function(ns, saved) {
+
+  save_btn <- tags$button(
+    id = ns("save_btn"),
+    class = "blockr-navbar-save-btn",
+    type = "button",
+    onclick = sprintf(
+      "Shiny.setInputValue('%s', Date.now(), {priority: 'event'})",
+      ns("save_btn")
+    ),
+    bsicons::bs_icon("floppy", size = "1em")
+  )
+
+  if (!saved) {
+    return(save_btn)
+  }
+
+  tagList(
+    save_btn,
+    tags$button(
+      class = paste(
+        "blockr-navbar-save-btn blockr-navbar-save-toggle",
+        "dropdown-toggle"
+      ),
+      type = "button",
+      `data-bs-toggle` = "dropdown",
+      `aria-expanded` = "false",
+      tags$span(class = "visually-hidden", "Toggle save menu")
+    ),
+    tags$ul(
+      class = "dropdown-menu dropdown-menu-end blockr-navbar-save-menu",
+      tags$li(
+        tags$button(
+          id = ns("save_as_btn"),
+          class = "dropdown-item",
+          type = "button",
+          onclick = sprintf(
+            "Shiny.setInputValue('%s', Date.now(), {priority: 'event'})",
+            ns("save_as_btn")
+          ),
+          bsicons::bs_icon("files"),
+          "Save as new workflow"
+        )
+      )
+    )
+  )
 }
 
 show_rack_id_modal <- function(session, default) {

--- a/R/server.R
+++ b/R/server.R
@@ -15,6 +15,7 @@ manage_project_server <- function(id, board, ...) {
 
       refresh_trigger <- reactiveVal(0)
       save_status <- reactiveVal("Not saved")
+      pending_save_mode <- reactiveVal(NULL)
 
       serialize_now <- function(id = board$board_id) {
         do.call(
@@ -26,13 +27,6 @@ manage_project_server <- function(id, board, ...) {
           )
         )
       }
-
-      board_name <- reactive(
-        coal(
-          get_board_option_or_null("board_name", session),
-          board$board_id
-        )
-      )
 
       prev_query <- reactiveVal(NULL)
 
@@ -55,6 +49,10 @@ manage_project_server <- function(id, board, ...) {
           list(id = qid, user = query$user)
         )
       })
+
+      current_rack_id <- reactive(
+        coal(current_id()$id, board$board_id, fail_all = FALSE)
+      )
 
       observeEvent(
         current_id(),
@@ -97,9 +95,9 @@ manage_project_server <- function(id, board, ...) {
         input$save_btn,
         {
           # Save keys on the board's stable id: a loaded record (current_id),
-          # else the board id. It appends a version to that record if it exists,
-          # else creates it under the board id -- so the record id and board id
-          # match. Only Save As mints a fresh board id to fork.
+          # else the board id. A first save of a not-yet-persisted board mints
+          # the record, so it opens the id chooser (like naming an untitled
+          # document); a save of an existing record appends a version silently.
           target <- coal(
             current_id(),
             rack_id_from_input(backend, list(id = board$board_id))
@@ -108,6 +106,15 @@ manage_project_server <- function(id, board, ...) {
           exists <- isTRUE(
             tryCatch(rack_exists(target, backend), error = function(e) FALSE)
           )
+
+          if (!exists) {
+            pending_save_mode("create")
+            show_rack_id_modal(
+              session,
+              default = coal(current_id()$id, board$board_id, fail_all = FALSE)
+            )
+            return()
+          }
 
           data <- tryCatch(
             serialize_now(),
@@ -118,20 +125,13 @@ manage_project_server <- function(id, board, ...) {
             return()
           }
 
-          if (exists && !rack_content_changed(target, backend, data)) {
+          if (!rack_content_changed(target, backend, data)) {
             notify("No changes to save", type = "message", session = session)
             return()
           }
 
           res <- tryCatch(
-            if (exists) {
-              rack_append(target, backend, data)
-            } else {
-              rack_create(
-                backend, data,
-                id = board$board_id, name = board_name()
-              )
-            },
+            rack_append(target, backend, data),
             error = cnd_to_notif(type = "error")
           )
 
@@ -140,8 +140,9 @@ manage_project_server <- function(id, board, ...) {
           }
 
           notify(
-            sprintf("Successfully saved %s (%s)", board_name(), res$id),
+            sprintf("Saved workflow %s", res$id),
             type = "message",
+            glue = FALSE,
             session = session
           )
           save_status("Just now")
@@ -160,7 +161,45 @@ manage_project_server <- function(id, board, ...) {
       observeEvent(
         input$save_as_btn,
         {
-          new_id <- rand_names()
+          pending_save_mode("fork")
+          show_rack_id_modal(session, default = rand_names())
+        }
+      )
+
+      observeEvent(
+        input$rack_id_confirm,
+        {
+          new_id <- trimws(coal(input$rack_id_input, ""))
+          mode <- pending_save_mode()
+
+          if (!valid_rack_id(new_id)) {
+            notify(
+              paste(
+                "Workflow ID may contain only letters, numbers, hyphens",
+                "and underscores."
+              ),
+              type = "error",
+              glue = FALSE,
+              session = session
+            )
+            return()
+          }
+
+          rid <- rack_id_from_input(backend, list(id = new_id))
+
+          record_exists <- isTRUE(
+            tryCatch(rack_exists(rid, backend), error = function(e) FALSE)
+          )
+
+          if (record_exists) {
+            notify(
+              sprintf("A workflow named %s already exists.", new_id),
+              type = "error",
+              glue = FALSE,
+              session = session
+            )
+            return()
+          }
 
           data <- tryCatch(
             serialize_now(new_id),
@@ -172,10 +211,7 @@ manage_project_server <- function(id, board, ...) {
           }
 
           res <- tryCatch(
-            rack_create(
-              backend, data,
-              id = new_id, name = board_name()
-            ),
+            rack_create(backend, data, id = new_id, name = new_id),
             error = cnd_to_notif(type = "error")
           )
 
@@ -183,13 +219,31 @@ manage_project_server <- function(id, board, ...) {
             return()
           }
 
-          forked <- rack_id_from_input(
+          removeModal(session)
+          refresh_trigger(refresh_trigger() + 1)
+
+          saved <- rack_id_from_input(
             backend,
             list(id = res$id, user = res$user)
           )
 
-          navigate_to_board(forked, backend, session)
-        }
+          if (identical(mode, "fork")) {
+            navigate_to_board(saved, backend, session)
+            return()
+          }
+
+          save_status("Just now")
+          new_url <- board_query_string(saved, backend)
+          prev_query(new_url)
+          updateQueryString(new_url, mode = "replace", session = session)
+          notify(
+            sprintf("Saved workflow %s", res$id),
+            type = "message",
+            glue = FALSE,
+            session = session
+          )
+        },
+        ignoreInit = TRUE
       )
 
       observeEvent(
@@ -280,10 +334,11 @@ manage_project_server <- function(id, board, ...) {
         }
       )
 
-      # Save status output
       output$save_status <- renderText(
         save_status()
       )
+
+      output$rack_id <- renderText(current_rack_id())
 
       observeEvent(
         input$load_workflow,
@@ -633,7 +688,7 @@ manage_project_server <- function(id, board, ...) {
           id <- current_id()
 
           if (not_null(id)) {
-            tags$span(board_name())
+            tags$span(current_rack_id())
           }
         }
       )
@@ -766,40 +821,6 @@ manage_project_server <- function(id, board, ...) {
             refresh_trigger(refresh_trigger() + 1)
           }
         }
-      )
-
-      # Title edit drives the rename (it isn't coupled to a save): the
-      # in-session option updates, and for a loaded record the backend's native
-      # name field is written too. An unsaved board carries the name until
-      # rack_create persists it on first save. `title_edit` fires on blur, so
-      # it is already one event per edit (no per-keystroke debounce needed).
-      observeEvent(
-        input$title_edit,
-        {
-          name <- input$title_edit
-
-          set_board_option_value("board_name", name, board$board, session)
-
-          id <- current_id()
-
-          if (not_null(id) && not_null(name) && nzchar(name)) {
-            current <- tryCatch(
-              rack_name(id, backend),
-              error = function(e) NULL
-            )
-            if (!identical(current, name)) {
-              tryCatch(
-                rack_rename(id, backend, name),
-                error = cnd_to_notif(type = "warning")
-              )
-            }
-          }
-        }
-      )
-
-      # Initialize title
-      observe(
-        session$sendCustomMessage("blockr-update-navbar-title", board_name())
       )
 
       # --- Sharing & visibility (capability-driven) ---
@@ -1241,6 +1262,28 @@ navigate_to_board <- function(id, backend, session) {
   )
 
   session$reload()
+}
+
+show_rack_id_modal <- function(session, default) {
+
+  ns <- session$ns
+
+  showModal(
+    modalDialog(
+      title = "Choose a workflow ID",
+      size = "s",
+      easyClose = TRUE,
+      textInput(ns("rack_id_input"), "Workflow ID", value = default),
+      tags$p(
+        class = "blockr-rack-id-hint",
+        "Letters, numbers, hyphens and underscores. Must be unique."
+      ),
+      footer = tagList(
+        modalButton("Cancel"),
+        actionButton(ns("rack_id_confirm"), "Save", class = "btn-primary")
+      )
+    )
+  )
 }
 
 shiny_input_js <- function(ns_id, value) {

--- a/R/ui.R
+++ b/R/ui.R
@@ -135,17 +135,12 @@ manage_project_ui <- function(id, x) {
           uiOutput(ns("sharing_panel"))
         )
       ),
-      # Read-only workflow (rack) ID
-      tags$div(
-        class = "blockr-navbar-title-wrapper",
-        tagAppendAttributes(
-          textOutput(ns("rack_id"), container = tags$span, inline = TRUE),
-          class = "blockr-navbar-title blockr-navbar-rack-id",
-          title = "Workflow ID"
-        )
+      # Read-only workflow (rack) ID -- rendered only once the workflow has a
+      # chosen id; an unsaved board has none, and "Not saved" carries that state
+      tagAppendAttributes(
+        uiOutput(ns("rack_id_area")),
+        class = "blockr-navbar-id-area"
       ),
-      # Divider
-      tags$span(class = "blockr-navbar-divider"),
       # Save status
       tags$div(
         class = "blockr-navbar-save-section",

--- a/R/ui.R
+++ b/R/ui.R
@@ -152,44 +152,11 @@ manage_project_ui <- function(id, x) {
           ),
           class = "blockr-navbar-meta"
         ),
-        tags$div(
-          class = "btn-group blockr-navbar-save-group",
-          tags$button(
-            id = ns("save_btn"),
-            class = "blockr-navbar-save-btn shiny-bound-input",
-            type = "button",
-            onclick = sprintf(
-              "Shiny.setInputValue('%s', Date.now(), {priority: 'event'})",
-              ns("save_btn")
-            ),
-            bsicons::bs_icon("floppy", size = "1em")
-          ),
-          tags$button(
-            class = paste(
-              "blockr-navbar-save-btn blockr-navbar-save-toggle",
-              "dropdown-toggle"
-            ),
-            type = "button",
-            `data-bs-toggle` = "dropdown",
-            `aria-expanded` = "false",
-            tags$span(class = "visually-hidden", "Toggle save menu")
-          ),
-          tags$ul(
-            class = "dropdown-menu dropdown-menu-end blockr-navbar-save-menu",
-            tags$li(
-              tags$button(
-                id = ns("save_as_btn"),
-                class = "dropdown-item",
-                type = "button",
-                onclick = sprintf(
-                  "Shiny.setInputValue('%s', Date.now(), {priority: 'event'})",
-                  ns("save_as_btn")
-                ),
-                bsicons::bs_icon("files"),
-                "Save as new workflow"
-              )
-            )
-          )
+        # Save on its own until the workflow is saved; the "Save as new
+        # workflow" split only appears once there is a record to fork from
+        tagAppendAttributes(
+          uiOutput(ns("save_controls")),
+          class = "btn-group blockr-navbar-save-group"
         )
       ),
       # New button

--- a/R/ui.R
+++ b/R/ui.R
@@ -135,47 +135,13 @@ manage_project_ui <- function(id, x) {
           uiOutput(ns("sharing_panel"))
         )
       ),
-      # Editable workflow title
+      # Read-only workflow (rack) ID
       tags$div(
-        id = ns("title_wrapper"),
         class = "blockr-navbar-title-wrapper",
-        tags$span(
-          id = ns("title_display"),
-          class = "blockr-navbar-title",
-          onclick = sprintf(
-            "document.getElementById('%s').classList.add('editing');
-            document.getElementById('%s').focus();
-            document.getElementById('%s').select();",
-            ns("title_wrapper"),
-            ns("title_input"),
-            ns("title_input")
-          ),
-          ""
-        ),
-        tags$input(
-          id = ns("title_input"),
-          class = "blockr-navbar-title-input shiny-bound-input",
-          type = "text",
-          value = "",
-          onblur = sprintf(
-            "Shiny.setInputValue('%s', this.value, {priority: 'event'});
-            document.getElementById('%s').classList.remove('editing');
-            document.getElementById('%s').textContent = this.value;",
-            ns("title_edit"),
-            ns("title_wrapper"),
-            ns("title_display")
-          ),
-          onkeydown = sprintf(
-            "if(event.key === 'Enter') {
-              this.blur();
-            }
-            if(event.key === 'Escape') {
-              document.getElementById('%s').classList.remove('editing');
-              this.value = document.getElementById('%s').textContent;
-            }",
-            ns("title_wrapper"),
-            ns("title_display")
-          )
+        tagAppendAttributes(
+          textOutput(ns("rack_id"), container = tags$span, inline = TRUE),
+          class = "blockr-navbar-title blockr-navbar-rack-id",
+          title = "Workflow ID"
         )
       ),
       # Divider

--- a/R/utils.R
+++ b/R/utils.R
@@ -142,6 +142,10 @@ reset_board_name <- function(board, name) {
   board
 }
 
+valid_rack_id <- function(x) {
+  is_string(x) && grepl("^[A-Za-z0-9_-]+$", x)
+}
+
 board_query_string <- function(id, backend) {
 
   params <- list(id = coal(id$id, id[["name"]], fail_all = FALSE))

--- a/inst/assets/css/project-navbar.css
+++ b/inst/assets/css/project-navbar.css
@@ -316,11 +316,11 @@
 }
 
 /* --- Workflow (rack) ID --- */
-.blockr-navbar-title-wrapper {
-  position: relative;
-  min-width: 120px;
+.blockr-navbar-id-area {
   display: flex;
   align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
 }
 
 .blockr-navbar-title {
@@ -335,6 +335,7 @@
 .blockr-navbar-rack-id {
   font-family: var(--bs-font-monospace, monospace);
   color: #555;
+  white-space: nowrap;
 }
 
 .blockr-rack-id-hint {

--- a/inst/assets/css/project-navbar.css
+++ b/inst/assets/css/project-navbar.css
@@ -315,7 +315,7 @@
   margin-bottom: 8px;
 }
 
-/* --- Editable Title --- */
+/* --- Workflow (rack) ID --- */
 .blockr-navbar-title-wrapper {
   position: relative;
   min-width: 120px;
@@ -329,49 +329,18 @@
   font-size: 0.875rem;
   font-weight: 500;
   color: #333;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  cursor: text;
-  transition: border-color 0.15s ease;
   line-height: 1.2;
 }
 
-.blockr-navbar-title:hover {
-  border-color: hsl(220, 3%, 85%);
+.blockr-navbar-rack-id {
+  font-family: var(--bs-font-monospace, monospace);
+  color: #555;
 }
 
-.blockr-navbar-title-input {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
-  width: 100%;
-  padding: 6px 10px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #333;
-  border: 2px solid #4a7dff;
-  border-radius: 6px;
-  background: white;
-  opacity: 0;
-  pointer-events: none;
-  line-height: 1.2;
-  box-sizing: border-box;
-}
-
-.blockr-navbar-title-input:focus {
-  outline: none;
-  border-color: #4a7dff;
-  box-shadow: 0 0 0 3px rgba(74, 125, 255, 0.15);
-}
-
-.blockr-navbar-title-wrapper.editing .blockr-navbar-title {
-  opacity: 0;
-}
-
-.blockr-navbar-title-wrapper.editing .blockr-navbar-title-input {
-  opacity: 1;
-  pointer-events: auto;
+.blockr-rack-id-hint {
+  margin: 4px 0 0;
+  font-size: 0.8rem;
+  color: hsl(220, 3%, 45%);
 }
 
 /* --- Divider --- */

--- a/inst/assets/js/project-navbar.js
+++ b/inst/assets/js/project-navbar.js
@@ -1,15 +1,5 @@
 // Project navbar JavaScript handlers
 
-// Update navbar title from server
-Shiny.addCustomMessageHandler('blockr-update-navbar-title', function(title) {
-  document.querySelectorAll('.blockr-navbar-title').forEach(function(el) {
-    el.textContent = title;
-  });
-  document.querySelectorAll('.blockr-navbar-title-input').forEach(function(el) {
-    el.value = title;
-  });
-});
-
 // --- Workflow list: keyboard nav + infinite scroll ------------------------
 // The server renders a window of the (server-filtered) list plus a sentinel at
 // the bottom; scrolling the sentinel into view asks the server for the next

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -61,28 +61,33 @@ test_that("manage_project ui", {
   expect_s3_class(manage_project_ui("project", new_board()), "shiny.tag.list")
 })
 
-test_that("manage_project ui puts Save As in a split-button dropdown (#67)", {
-  doc <- xml2::read_html(
-    as.character(manage_project_ui("project", new_board()))
-  )
+test_that("save-as appears in the split menu only once saved (#67, #81)", {
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
 
-  save_btn <- xml2::xml_find_all(doc, "//button[@id='project-save_btn']")
-  expect_length(save_btn, 1)
-  expect_match(xml2::xml_attr(save_btn, "onclick"), "save_btn", fixed = TRUE)
+  test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
 
-  toggle <- xml2::xml_find_all(
-    doc,
-    paste0(
-      "//button[@data-bs-toggle='dropdown' and contains(",
-      "concat(' ', normalize-space(@class), ' '), ' dropdown-toggle ')]"
+  testServer(
+    manage_project_server,
+    {
+      # unsaved: a bare Save button, no split dropdown and no Save As
+      unsaved <- output$save_controls
+      expect_true(any(grepl("save_btn", unsaved, fixed = TRUE)))
+      expect_false(any(grepl("save_as_btn", unsaved, fixed = TRUE)))
+      expect_false(any(grepl("dropdown-toggle", unsaved, fixed = TRUE)))
+
+      prev_query("?id=saveas-test")
+      session$flushReact()
+
+      # saved: the split dropdown carrying Save As appears
+      saved <- output$save_controls
+      expect_true(any(grepl("save_as_btn", saved, fixed = TRUE)))
+      expect_true(any(grepl("dropdown-toggle", saved, fixed = TRUE)))
+    },
+    args = list(
+      board = reactiveValues(board = test_board, board_id = "saveas-test")
     )
   )
-  expect_length(toggle, 1)
-
-  save_as <- xml2::xml_find_all(doc, "//button[@id='project-save_as_btn']")
-  expect_length(save_as, 1)
-  expect_match(xml2::xml_attr(save_as, "class"), "dropdown-item")
-  expect_match(xml2::xml_attr(save_as, "onclick"), "save_as_btn", fixed = TRUE)
 })
 
 test_that("save persists board to backend", {

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -1,3 +1,9 @@
+# Drive the first-save id chooser: open it with Save, then confirm the id.
+first_save <- function(session, id, n = 1L) {
+  session$setInputs(save_btn = n)
+  session$setInputs(rack_id_input = id, rack_id_confirm = n)
+}
+
 test_that("manage_project plugin", {
 
   a <- manage_project()
@@ -26,7 +32,7 @@ test_that("manage_project server", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "test")
       expect_no_error(session$flushReact())
     },
     args = list(board = reactiveValues(board = test_board, board_id = "test"))
@@ -48,36 +54,6 @@ test_that("manage_project server", {
       expect_no_error(session$flushReact())
     },
     args = list(board = reactiveValues(board = test_board, board_id = "test"))
-  )
-})
-
-test_that("title edit forwards a board to set_board_option_value (#60)", {
-
-  withr::local_options(
-    blockr.session_mgmt_backend = pins::board_temp(versioned = TRUE)
-  )
-
-  captured <- new.env()
-
-  testServer(
-    manage_project_server,
-    {
-      local_mocked_bindings(
-        set_board_option_value = function(opt, val, board, ...) {
-          captured$board <- board
-          invisible(val)
-        },
-        .package = "blockr.session"
-      )
-
-      session$setInputs(title_edit = "Renamed board")
-      session$flushReact()
-
-      expect_true(is_board(captured$board))
-    },
-    args = list(
-      board = reactiveValues(board = new_board(), board_id = "title-test")
-    )
   )
 })
 
@@ -120,7 +96,7 @@ test_that("save persists board to backend", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "save-test")
       expect_equal(output$save_status, "Just now")
     },
     args = list(
@@ -143,83 +119,13 @@ test_that("recent_workflows renders the saved record keyed on its id (#61)", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "rebel_eyas")
       html <- as.character(output$recent_workflows)
 
       expect_true(any(grepl("rebel_eyas", html, fixed = TRUE)))
     },
     args = list(
       board = reactiveValues(board = test_board, board_id = "rebel_eyas")
-    )
-  )
-})
-
-test_that("editing the title renames the loaded record (#61)", {
-  backend <- pins::board_temp(versioned = TRUE)
-  withr::local_options(blockr.session_mgmt_backend = backend)
-
-  # an existing record we're editing; stored name differs from the edit
-  rack_create(backend, list(blocks = list()), id = "rename-edit",
-              name = "Old name")
-
-  renamed_to <- NULL
-  local_mocked_bindings(
-    set_board_option_value = function(opt, val, board, ...) invisible(val),
-    rack_rename = function(id, backend, name, ...) {
-      renamed_to <<- name
-      id
-    },
-    .package = "blockr.session"
-  )
-
-  test_board <- new_board(
-    blocks = c(a = new_dataset_block("iris"))
-  )
-
-  testServer(
-    manage_project_server,
-    {
-      prev_query("?id=rename-edit")     # a loaded record (current_id set)
-      session$setInputs(title_edit = "New name")
-      session$flushReact()
-
-      expect_equal(renamed_to, "New name")
-    },
-    args = list(
-      board = reactiveValues(board = test_board, board_id = "rename-edit")
-    )
-  )
-})
-
-test_that("editing the title of an unsaved board does not rename (#61)", {
-  backend <- pins::board_temp(versioned = TRUE)
-  withr::local_options(blockr.session_mgmt_backend = backend)
-
-  renamed <- FALSE
-  local_mocked_bindings(
-    set_board_option_value = function(opt, val, board, ...) invisible(val),
-    rack_rename = function(id, backend, name, ...) {
-      renamed <<- TRUE
-      id
-    },
-    .package = "blockr.session"
-  )
-
-  test_board <- new_board(
-    blocks = c(a = new_dataset_block("iris"))
-  )
-
-  testServer(
-    manage_project_server,
-    {
-      # no current_id (unsaved board): the name rides along until first save
-      session$setInputs(title_edit = "Fresh name")
-      session$flushReact()
-
-      expect_false(renamed)
-    },
-    args = list(
-      board = reactiveValues(board = test_board, board_id = "unsaved-board")
     )
   )
 })
@@ -298,7 +204,7 @@ test_that("saving after a content change creates a new version", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "version-test")
       Sys.sleep(1)
       # a real content change between saves
       board$board <- new_board(
@@ -326,7 +232,7 @@ test_that("a no-op save does not create a new version (#61)", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "noop-test")
       Sys.sleep(1)
       session$setInputs(save_btn = 2)   # nothing changed since the first save
     },
@@ -402,11 +308,12 @@ test_that("save_as forks the loaded board into a fresh record (#67)", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "fork-origin")
       session$flushReact()
 
       prev_query("?id=fork-origin")
       session$setInputs(save_as_btn = 1)
+      session$setInputs(rack_id_input = "fork-copy", rack_id_confirm = 2)
       session$flushReact()
     },
     args = list(
@@ -449,7 +356,7 @@ test_that("loader resolve loads a saved board from the backend", {
 
   testServer(
     manage_project_server,
-    session$setInputs(save_btn = 1),
+    first_save(session, "loader-test"),
     args = list(
       board = reactiveValues(board = test_board, board_id = "loader-test")
     )
@@ -471,7 +378,7 @@ test_that("loader resolve still reads a legacy board_name handle", {
 
   testServer(
     manage_project_server,
-    session$setInputs(save_btn = 1),
+    first_save(session, "legacy-test"),
     args = list(
       board = reactiveValues(board = test_board, board_id = "legacy-test")
     )
@@ -505,7 +412,7 @@ test_that("loader GET user-scopes via the configured user_pins_board (#70)", {
     list(blockr.session_mgmt_backend = visitor_backend),
     testServer(
       manage_project_server,
-      session$setInputs(save_btn = 1),
+      first_save(session, "scoped"),
       args = list(
         board = reactiveValues(board = seed, board_id = "scoped")
       )
@@ -537,7 +444,7 @@ test_that("loader leaves a non-Connect backend untouched under a token (#70)", {
 
   testServer(
     manage_project_server,
-    session$setInputs(save_btn = 1),
+    first_save(session, "shared"),
     args = list(
       board = reactiveValues(board = seed, board_id = "shared")
     )
@@ -569,7 +476,7 @@ test_that("loader WS user-scopes via the configured user_pins_board (#70)", {
     list(blockr.session_mgmt_backend = visitor_backend),
     testServer(
       manage_project_server,
-      session$setInputs(save_btn = 1),
+      first_save(session, "ws-scoped"),
       args = list(
         board = reactiveValues(board = seed, board_id = "ws-scoped")
       )
@@ -632,7 +539,7 @@ test_that("version history marks the URL version as current (#19)", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "hist-current")
       Sys.sleep(1)
       board$board <- new_board(
         blocks = c(a = new_dataset_block("iris"), b = new_subset_block())
@@ -676,7 +583,7 @@ test_that("delete_workflows removes pin from backend", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "del-test")
     },
     args = list(
       board = reactiveValues(board = test_board, board_id = "del-test")
@@ -711,7 +618,7 @@ test_that("delete_versions removes specific version", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "ver-del-test")
       Sys.sleep(1)
       board$board <- new_board(
         blocks = c(a = new_dataset_block("iris"), b = new_subset_block())
@@ -752,7 +659,7 @@ test_that("version_history output shows versions after save", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "vh-test")
       Sys.sleep(1)
       session$setInputs(save_btn = 2)
 
@@ -815,7 +722,7 @@ test_that("expanding a picker row surfaces that workflow's version history", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "vvf-test")
 
       session$setInputs(modal_toggle_expand = list(id = "other-wf", user = ""))
       session$flushReact()
@@ -850,7 +757,7 @@ test_that("delete_versions removes a version from the named record", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "dvf-test")
       Sys.sleep(1)
       board$board <- new_board(
         blocks = c(a = new_dataset_block("iris"), b = new_subset_block())
@@ -919,7 +826,7 @@ test_that("view_all_versions triggers modal", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "vav-test")
       Sys.sleep(1)
       session$setInputs(save_btn = 2)
       session$setInputs(view_all_versions = 1)
@@ -1014,7 +921,7 @@ test_that("sharing observers fire with sharing-capable backend", {
   testServer(
     manage_project_server,
     {
-      session$setInputs(save_btn = 1)
+      first_save(session, "sharing-obs-test")
 
       session$setInputs(visibility_change = "all")
       expect_no_error(session$flushReact())
@@ -1029,4 +936,102 @@ test_that("sharing observers fire with sharing-capable backend", {
       board = reactiveValues(board = test_board, board_id = "sharing-obs-test")
     )
   )
+})
+
+test_that("navbar shows a read-only rack id, not an editable title (#81)", {
+  doc <- xml2::read_html(
+    as.character(manage_project_ui("project", new_board()))
+  )
+
+  rack_id <- xml2::xml_find_all(doc, "//*[@id='project-rack_id']")
+  expect_length(rack_id, 1)
+  expect_match(xml2::xml_attr(rack_id, "class"), "blockr-navbar-rack-id")
+
+  title_input <- xml2::xml_find_all(doc, "//input[@id='project-title_input']")
+  expect_length(title_input, 0)
+})
+
+test_that("the rack id output reflects the loaded record (#81)", {
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  testServer(
+    manage_project_server,
+    {
+      expect_equal(output$rack_id, "fresh-board")
+
+      prev_query("?id=loaded-board")
+      session$flushReact()
+      expect_equal(output$rack_id, "loaded-board")
+    },
+    args = list(
+      board = reactiveValues(board = test_board, board_id = "fresh-board")
+    )
+  )
+})
+
+test_that("first save mints the chosen id, not the board id (#81)", {
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  testServer(
+    manage_project_server,
+    {
+      session$setInputs(save_btn = 1)
+      session$setInputs(rack_id_input = "chosen-id", rack_id_confirm = 1)
+    },
+    args = list(
+      board = reactiveValues(board = test_board, board_id = "auto-slug")
+    )
+  )
+
+  expect_true("chosen-id" %in% pins::pin_list(backend))
+  expect_false("auto-slug" %in% pins::pin_list(backend))
+})
+
+test_that("the id chooser rejects an invalid id (#81)", {
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  testServer(
+    manage_project_server,
+    {
+      session$setInputs(save_btn = 1)
+      session$setInputs(rack_id_input = "no spaces!", rack_id_confirm = 1)
+    },
+    args = list(
+      board = reactiveValues(board = test_board, board_id = "invalid-test")
+    )
+  )
+
+  expect_length(pins::pin_list(backend), 0L)
+})
+
+test_that("the id chooser refuses to overwrite an existing id (#81)", {
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  rack_create(backend, list(blocks = list()), id = "taken", name = "taken")
+
+  test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  testServer(
+    manage_project_server,
+    {
+      session$setInputs(save_btn = 1)
+      session$setInputs(rack_id_input = "taken", rack_id_confirm = 1)
+    },
+    args = list(
+      board = reactiveValues(board = test_board, board_id = "collision-test")
+    )
+  )
+
+  expect_equal(pins::pin_list(backend), "taken")
+  expect_equal(nrow(pins::pin_versions(backend, "taken")), 1L)
 })

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -938,20 +938,19 @@ test_that("sharing observers fire with sharing-capable backend", {
   )
 })
 
-test_that("navbar shows a read-only rack id, not an editable title (#81)", {
+test_that("navbar shows a rack id area, not an editable title (#81)", {
   doc <- xml2::read_html(
     as.character(manage_project_ui("project", new_board()))
   )
 
-  rack_id <- xml2::xml_find_all(doc, "//*[@id='project-rack_id']")
-  expect_length(rack_id, 1)
-  expect_match(xml2::xml_attr(rack_id, "class"), "blockr-navbar-rack-id")
+  area <- xml2::xml_find_all(doc, "//*[@id='project-rack_id_area']")
+  expect_length(area, 1)
 
   title_input <- xml2::xml_find_all(doc, "//input[@id='project-title_input']")
   expect_length(title_input, 0)
 })
 
-test_that("the rack id output reflects the loaded record (#81)", {
+test_that("the rack id area shows only for a saved workflow (#81)", {
   backend <- pins::board_temp(versioned = TRUE)
   withr::local_options(blockr.session_mgmt_backend = backend)
 
@@ -960,11 +959,12 @@ test_that("the rack id output reflects the loaded record (#81)", {
   testServer(
     manage_project_server,
     {
-      expect_equal(output$rack_id, "fresh-board")
+      # a never-saved board has no chosen id, so the area renders nothing
+      expect_error(output$rack_id_area, class = "shiny.silent.error")
 
       prev_query("?id=loaded-board")
       session$flushReact()
-      expect_equal(output$rack_id, "loaded-board")
+      expect_true(any(grepl("loaded-board", output$rack_id_area, fixed = TRUE)))
     },
     args = list(
       board = reactiveValues(board = test_board, board_id = "fresh-board")


### PR DESCRIPTION
## Summary

- The navbar showed an editable board-name field, but the stable handle for a workflow is its rack ID (the URL query and the backend storage key). The name and the ID could diverge, and there was no way to choose the ID when forking. This surfaces the rack ID read-only in the navbar and lets the user pick it at save time.
- The ID is shown **only once the workflow is saved** — an unsaved board has no chosen ID, so displaying its auto-generated `board_id` would read as an identity the user never picked. Until then, "Not saved" is the sole unsaved signal; the ID appears when it's chosen at save.
- **First save** of a never-saved board opens a "Choose a workflow ID" dialog (prefilled with a suggested slug, validated to a unique id of letters/numbers/hyphens/underscores). **Save As** is offered only once a record exists to fork — before the first save it would be identical to Save, so the split-button dropdown collapses to a bare Save button until then.
- `board_name` is not removed — it stays editable in the board-options menu as an optional display name (most users won't need it). The navbar no longer drives renames, so the obsolete `title_edit` observer and `blockr-update-navbar-title` JS handler are gone.

Fixes #81
