### PR TITLE
Mint a fresh board id when hitting New

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -152,7 +152,7 @@ manage_project_server <- function(id, board, ...) {
             backend,
             list(id = res$id, user = res$user)
           )
-          new_url <- board_query_string(saved, backend)
+          new_url <- board_query_string(saved, backend, keep = current_query())
           prev_query(new_url)
           updateQueryString(new_url, mode = "replace", session = session)
         }
@@ -233,7 +233,7 @@ manage_project_server <- function(id, board, ...) {
           }
 
           save_status("Just now")
-          new_url <- board_query_string(saved, backend)
+          new_url <- board_query_string(saved, backend, keep = current_query())
           prev_query(new_url)
           updateQueryString(new_url, mode = "replace", session = session)
           notify(
@@ -250,7 +250,9 @@ manage_project_server <- function(id, board, ...) {
         input$new_btn,
         {
           updateQueryString(
-            paste0("?new=", rand_names()),
+            build_query_string(
+              c(list(new = rand_names()), drop_session_query(current_query()))
+            ),
             mode = "replace",
             session = session
           )
@@ -1296,7 +1298,11 @@ workflow_item <- function(wf, backend, ns) {
 navigate_to_board <- function(id, backend, session) {
 
   updateQueryString(
-    board_query_string(id, backend),
+    board_query_string(
+      id,
+      backend,
+      keep = isolate(session$clientData$url_search)
+    ),
     mode = "replace",
     session = session
   )

--- a/R/server.R
+++ b/R/server.R
@@ -249,7 +249,11 @@ manage_project_server <- function(id, board, ...) {
       observeEvent(
         input$new_btn,
         {
-          updateQueryString("?", mode = "replace", session = session)
+          updateQueryString(
+            paste0("?new=", rand_names()),
+            mode = "replace",
+            session = session
+          )
           session$reload()
         }
       )
@@ -1142,7 +1146,9 @@ manage_project_server <- function(id, board, ...) {
 #' A [blockr.core::board_loader()] for [blockr.core::serve()] that picks the
 #' board to build from the request URL. The board named by the URL handle
 #' (`board_name` / `user` / `version`) loads from the `session_mgmt_backend`
-#' backend; a request without such a handle (a cold load, or a "New" board)
+#' backend; a `new` handle (minted when the user hits New) yields an empty
+#' board under that fresh id, so saving it forks a distinct record rather than
+#' overwriting the served board; a request without any handle (a cold load)
 #' gets a cleared copy of the served board. The backend is resolved with the
 #' loader's own request (at the GET, before any session) or session (at the WS
 #' connect), so a user-scoped backend such as [user_pins_board()] resolves
@@ -1168,6 +1174,16 @@ rack_loader <- function() {
     }
 
     query <- parseQueryString(coal(search, ""))
+
+    # the fresh id rides in the URL rather than being minted here: resolve runs
+    # once at the GET and again at the WS connect, and the id becomes the board
+    # module's namespace at both, so it must be identical across the two phases.
+    fresh <- query[["new"]]
+
+    if (not_null(fresh) && nzchar(fresh)) {
+      return(new_rack_board(default, fresh))
+    }
+
     handle <- coal(query$id, query$board_name, fail_all = FALSE)
 
     if (is.null(handle) || !nzchar(handle)) {
@@ -1211,6 +1227,14 @@ rack_loader <- function() {
   }
 
   board_loader(resolve)
+}
+
+new_rack_board <- function(board, id) {
+
+  board <- clear_board(board)
+  attr(board, "id") <- id
+
+  reset_board_name(board, id_to_sentence_case(id))
 }
 
 # A URL may point at a pin that is not a blockr workflow -- directly, or because

--- a/R/utils.R
+++ b/R/utils.R
@@ -146,7 +146,28 @@ valid_rack_id <- function(x) {
   is_string(x) && grepl("^[A-Za-z0-9_-]+$", x)
 }
 
-board_query_string <- function(id, backend) {
+# the query keys rack_loader() interprets; everything else in the URL is
+# preserved across New and save/navigate so app-level params survive.
+session_query_keys <- c("id", "board_name", "user", "version", "new")
+
+drop_session_query <- function(query) {
+  parsed <- parseQueryString(coal(query, ""))
+  parsed[setdiff(names(parsed), session_query_keys)]
+}
+
+build_query_string <- function(params) {
+  paste0(
+    "?",
+    paste(
+      names(params),
+      chr_ply(params, utils::URLencode, reserved = TRUE),
+      sep = "=",
+      collapse = "&"
+    )
+  )
+}
+
+board_query_string <- function(id, backend, keep = NULL) {
 
   params <- list(id = coal(id$id, id[["name"]], fail_all = FALSE))
 
@@ -158,8 +179,5 @@ board_query_string <- function(id, backend) {
     params$version <- id$version
   }
 
-  paste0(
-    "?",
-    paste(names(params), params, sep = "=", collapse = "&")
-  )
+  build_query_string(c(params, drop_session_query(keep)))
 }

--- a/man/rack_loader.Rd
+++ b/man/rack_loader.Rd
@@ -13,7 +13,9 @@ A \code{\link[blockr.core:board_loader]{blockr.core::board_loader()}} object.
 A \code{\link[blockr.core:board_loader]{blockr.core::board_loader()}} for \code{\link[blockr.core:serve]{blockr.core::serve()}} that picks the
 board to build from the request URL. The board named by the URL handle
 (\code{board_name} / \code{user} / \code{version}) loads from the \code{session_mgmt_backend}
-backend; a request without such a handle (a cold load, or a "New" board)
+backend; a \code{new} handle (minted when the user hits New) yields an empty
+board under that fresh id, so saving it forks a distinct record rather than
+overwriting the served board; a request without any handle (a cold load)
 gets a cleared copy of the served board. The backend is resolved with the
 loader's own request (at the GET, before any session) or session (at the WS
 connect), so a user-scoped backend such as \code{\link[=user_pins_board]{user_pins_board()}} resolves

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -464,6 +464,10 @@ test_that("New navigates to a fresh `?new=` id the loader honors (#68)", {
 
   expect_match(seen, "^\\?new=")
 
+  # a non-session param in the URL survives New (MockShinySession seeds
+  # url_search with ?mocksearch=1)
+  expect_identical(parseQueryString(seen)[["mocksearch"]], "1")
+
   fresh_id <- parseQueryString(seen)[["new"]]
   reloaded <- rack_loader()$resolve(
     list(QUERY_STRING = sub("^\\?", "", seen)), NULL, new_board()

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -408,6 +408,71 @@ test_that("loader resolve serves the cleared default for an unknown board", {
   expect_length(board_block_ids(res), 0)
 })
 
+test_that("loader resolve mints a fresh board for a `new` handle (#68)", {
+  initial <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  res <- rack_loader()$resolve(
+    list(QUERY_STRING = "new=rebel_eyas"), NULL, initial
+  )
+
+  expect_s3_class(res, "board")
+  expect_length(board_block_ids(res), 0)
+  expect_identical(attr(res, "id"), "rebel_eyas")
+  expect_identical(
+    board_option_value(board_options(res)[["board_name"]]),
+    "Rebel eyas"
+  )
+})
+
+test_that("loader derives the `new` id identically at GET and WS (#68)", {
+  initial <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  get_phase <- rack_loader()$resolve(
+    list(QUERY_STRING = "new=rebel_eyas"), NULL, initial
+  )
+
+  ws_phase <- rack_loader()$resolve(
+    NULL,
+    list(request = list(), clientData = list(url_search = "?new=rebel_eyas")),
+    initial
+  )
+
+  expect_identical(attr(get_phase, "id"), "rebel_eyas")
+  expect_identical(attr(ws_phase, "id"), attr(get_phase, "id"))
+})
+
+test_that("New navigates to a fresh `?new=` id the loader honors (#68)", {
+  withr::local_options(
+    blockr.session_mgmt_backend = pins::board_temp(versioned = TRUE)
+  )
+
+  seen <- NULL
+  local_mocked_bindings(
+    updateQueryString = function(query, ...) seen <<- query
+  )
+
+  testServer(
+    manage_project_server,
+    {
+      session$setInputs(new_btn = 1)
+      session$flushReact()
+    },
+    args = list(
+      board = reactiveValues(board = new_board(), board_id = "served")
+    )
+  )
+
+  expect_match(seen, "^\\?new=")
+
+  fresh_id <- parseQueryString(seen)[["new"]]
+  reloaded <- rack_loader()$resolve(
+    list(QUERY_STRING = sub("^\\?", "", seen)), NULL, new_board()
+  )
+
+  expect_identical(attr(reloaded, "id"), fresh_id)
+  expect_false(identical(fresh_id, "served"))
+})
+
 test_that("loader GET user-scopes via the configured user_pins_board (#70)", {
   visitor_backend <- pins::board_temp(versioned = TRUE)
 

--- a/tests/testthat/test-url.R
+++ b/tests/testthat/test-url.R
@@ -51,3 +51,27 @@ test_that("board_query_string accepts a rack_record", {
   backend <- pins::board_temp()
   expect_equal(board_query_string(rec, backend), "?id=slug")
 })
+
+test_that("board_query_string keep preserves non-session params", {
+  id <- new_rack_id_pins("my_board")
+  backend <- pins::board_temp()
+  expect_equal(
+    board_query_string(id, backend, keep = "?new=xyz&theme=dark&tab=2"),
+    "?id=my_board&theme=dark&tab=2"
+  )
+})
+
+test_that("drop_session_query keeps only non-session query params", {
+  keep <- drop_session_query(
+    "?id=b&board_name=n&user=u&version=v&new=x&theme=dark&tab=2"
+  )
+  expect_named(keep, c("theme", "tab"))
+  expect_equal(keep[["theme"]], "dark")
+})
+
+test_that("build_query_string url-encodes reserved characters in values", {
+  expect_equal(
+    build_query_string(list(id = "b", q = "a b")),
+    "?id=b&q=a%20b"
+  )
+})


### PR DESCRIPTION
## Summary

- New resolved to `clear_board(default)`, which keeps the served board's static id (the app-startup `serve(id = rand_names())`). So every New shared one id, and once storage keys on the board id (#61) each save clobbered the same record instead of forking a new one. Follow-up to #56.
- New now navigates to `?new=<fresh-id>` and reloads; the loader honours a `new` handle by returning an empty board that carries that fresh id (and a matching display name), so the first save forks a distinct record.
- The fresh id rides in the URL rather than being minted inside `resolve()`: `resolve` runs once at the GET and again at the WS connect, and `attr(x, "id")` becomes the board module's namespace at both (`id <- coal(attr(x, "id"), id)` in `serve_board_ui`/`serve_board_srv`), so a per-resolve `rand_names()` would diverge between the two phases and break the module wiring. The pre-loader `new_btn` sidestepped this by staging the whole board behind a URL token; the resolve-only rework dropped staging, so the id itself is the smallest thing that must stay identical across the reload.
- Non-session query params now survive New and every save/navigate. Those URL rewrites previously replaced the whole query string, dropping anything that wasn't a board handle. They now route through `drop_session_query()` + `build_query_string()`, which set/drop only the loader's keys (`id` / `board_name` / `user` / `version` / `new`) and carry everything else through (URL-encoding values). This is also what removes the transient `?new=` on the first save — surgically, rather than by blanket replacement.
- Cold load (no handle) is deliberately unchanged — it still serves the cleared default under the served id, preserving the cold re-save-appends behaviour (#61). The `?new=` param is forward-compatible with the "new empty vs new initial" modes and the fork-current variant raised in the issue comments, left as follow-ups.

Fixes #68
