### PR TITLE
Drop the unreachable Connect tagged-listing path

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -84,10 +84,6 @@ rack_rename.rack_id_pins_connect <- function(id, backend, name, ...) {
 #' @export
 rack_list.pins_board_connect <- function(backend, tags = NULL, ...) {
 
-  if (not_null(tags)) {
-    return(connect_list_tagged(backend, tags))
-  }
-
   tag_id <- connect_tag_id(backend)
 
   if (not_null(tag_id)) {
@@ -154,34 +150,6 @@ connect_sort_records <- function(records) {
   )
 
   records[order(key, decreasing = TRUE, na.last = TRUE)]
-}
-
-connect_list_tagged <- function(backend, tags) {
-
-  df <- filter_workflows(pins::pin_search(backend), tags)
-
-  if (nrow(df) == 0L) {
-    return(list())
-  }
-
-  titles <- tryCatch(
-    connect_content_titles(backend),
-    error = function(e) list()
-  )
-
-  lapply(
-    seq_len(nrow(df)),
-    function(i) {
-      parts <- strsplit(df$name[i], "/", fixed = TRUE)[[1L]]
-      slug <- parts[2L]
-      new_rack_record(
-        id = slug,
-        name = coal(titles[[slug]], slug, fail_all = FALSE),
-        user = parts[1L],
-        saved = df$created[i]
-      )
-    }
-  )
 }
 
 connect_item_title <- function(item) {
@@ -582,30 +550,6 @@ connect_content_find <- function(board, name) {
   }
 
   results[[1L]]
-}
-
-connect_content_titles <- function(board) {
-
-  results <- connect_api(board, "GET /content")
-
-  out <- list()
-
-  for (item in results) {
-
-    slug <- item$name
-
-    if (is.null(slug) || !nzchar(slug)) {
-      next
-    }
-
-    out[[slug]] <- if (not_null(item$title) && nzchar(item$title)) {
-      item$title
-    } else {
-      slug
-    }
-  }
-
-  out
 }
 
 connect_parse_time <- function(x) {

--- a/tests/testthat/test-pins.R
+++ b/tests/testthat/test-pins.R
@@ -645,22 +645,35 @@ test_that("connect_owner_cache resolves an owner once and caches it", {
   expect_equal(calls, 1L)
 })
 
-test_that("rack_list on Connect with tags uses the pin_search path", {
+test_that("rack_list on Connect ignores the tags argument", {
 
   board <- mock_board_connect()
+  connect_owner_cache$reset()
+  withr::defer(connect_owner_cache$reset())
 
   local_mocked_bindings(
-    pin_search = function(...) {
-      df <- data.frame(name = "user_a/wf", stringsAsFactors = FALSE)
-      df$meta <- list(list(tags = c("blockr-session", "prod")))
-      df$created <- as.POSIXct("2020-01-01", tz = "UTC")
-      df
-    },
+    connect_api = function(board, route, ...) {
+      if (grepl("GET /users", route, fixed = TRUE)) {
+        return(list(username = "user_a"))
+      }
+      if (identical(route, "GET /content")) {
+        return(
+          list(
+            list(name = "wf", title = "WF", content_category = "pin",
+                 owner_guid = "g", last_deployed_time = "2020-01-01T00:00:00Z")
+          )
+        )
+      }
+      list()
+    }
+  )
+  local_mocked_bindings(
+    pin_search = function(...) stop("Connect listing must not call pin_search"),
+    pin_meta = function(...) stop("Connect listing must not probe pins"),
     .package = "pins"
   )
-  local_mocked_bindings(connect_content_titles = function(backend) list())
 
-  result <- rack_list(board, tags = "prod")
+  result <- rack_list(board, tags = "does-not-match")
 
   expect_length(result, 1L)
   expect_equal(result[[1L]]$id, "wf")


### PR DESCRIPTION
## Summary

- `connect_list_tagged` — the only route to `pins::pin_search()` on a Connect board, whose method caps enumeration at 1000 pins and silently drops the rest (#89) — runs only when `rack_list` gets a non-NULL `tags` argument. But `rack_list` is an internal (unexported) generic and its sole caller in the whole stack (`server.R`) passes no tags, so that branch is dead: the cap can't actually be reached.
- #90 already moved Connect listing to server-side native-tag filtering (`session_connect_tag` → `GET /tags/{id}/content`) or, unconfigured, listing every pin via `GET /content` and checking blockr membership on load. This bundle-tag path was left behind — superseded and unreachable.
- So rather than un-cap a dead path (the first take on this PR), remove it: drop the `tags` dispatch branch, `connect_list_tagged`, and the now-unused `connect_content_titles`. Connect ignores the `tags` argument by design; the per-pin `blockr-session` check stays at load time in `rack_download`.
- The test asserts Connect lists a pin regardless of a non-matching `tags` filter and never calls `pin_search`/`pin_meta` — verified it errors against the pre-removal probing code, so it also guards against anyone re-adding a per-pin listing probe.

Fixes #89
