### PR TITLE
Add a "New in new tab" option to the New button

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -362,6 +362,15 @@ manage_project_server <- function(id, board, ...) {
         save_controls(session$ns, saved = not_null(current_id()))
       )
 
+      output$new_controls <- renderUI(
+        new_controls(
+          session$ns,
+          build_query_string(
+            c(list(new = rand_names()), drop_session_query(current_query()))
+          )
+        )
+      )
+
       observeEvent(
         input$load_workflow,
         navigate_to_board(
@@ -1352,6 +1361,47 @@ save_controls <- function(ns, saved) {
           ),
           bsicons::bs_icon("files"),
           "Save as new workflow"
+        )
+      )
+    )
+  )
+}
+
+new_controls <- function(ns, new_tab_href) {
+
+  new_btn <- tags$button(
+    id = ns("new_btn"),
+    class = "blockr-navbar-btn-new",
+    type = "button",
+    onclick = sprintf(
+      "Shiny.setInputValue('%s', Date.now(), {priority: 'event'})",
+      ns("new_btn")
+    ),
+    bsicons::bs_icon("plus"),
+    "New"
+  )
+
+  tagList(
+    new_btn,
+    tags$button(
+      class = paste(
+        "blockr-navbar-btn-new blockr-navbar-new-toggle",
+        "dropdown-toggle"
+      ),
+      type = "button",
+      `data-bs-toggle` = "dropdown",
+      `aria-expanded` = "false",
+      tags$span(class = "visually-hidden", "Toggle new menu")
+    ),
+    tags$ul(
+      class = "dropdown-menu dropdown-menu-end blockr-navbar-new-menu",
+      tags$li(
+        tags$a(
+          class = "dropdown-item",
+          href = new_tab_href,
+          target = "_blank",
+          bsicons::bs_icon("box-arrow-up-right"),
+          "New in new tab"
         )
       )
     )

--- a/R/ui.R
+++ b/R/ui.R
@@ -159,17 +159,11 @@ manage_project_ui <- function(id, x) {
           class = "btn-group blockr-navbar-save-group"
         )
       ),
-      # New button
-      tags$button(
-        id = ns("new_btn"),
-        class = "blockr-navbar-btn-new shiny-bound-input",
-        type = "button",
-        onclick = sprintf(
-          "Shiny.setInputValue('%s', Date.now(), {priority: 'event'})",
-          ns("new_btn")
-        ),
-        bsicons::bs_icon("plus"),
-        "New"
+      # New split button: "New" creates in place; caret opens a fresh
+      # board in a new tab
+      tagAppendAttributes(
+        uiOutput(ns("new_controls")),
+        class = "btn-group blockr-navbar-new-group"
       ),
       # Spacer to push avatar to the right
       tags$span(class = "manage-project-spacer"),

--- a/inst/assets/css/project-navbar.css
+++ b/inst/assets/css/project-navbar.css
@@ -413,7 +413,8 @@
   margin: 0;
 }
 
-.blockr-navbar-save-menu {
+.blockr-navbar-save-menu,
+.blockr-navbar-new-menu {
   min-width: 200px;
   margin-top: 6px;
   padding: 6px;
@@ -422,7 +423,8 @@
   box-shadow: 0 10px 25px -8px rgb(0 0 0 / 0.2);
 }
 
-.blockr-navbar-save-menu .dropdown-item {
+.blockr-navbar-save-menu .dropdown-item,
+.blockr-navbar-new-menu .dropdown-item {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -433,12 +435,15 @@
 }
 
 .blockr-navbar-save-menu .dropdown-item:hover,
-.blockr-navbar-save-menu .dropdown-item:focus {
+.blockr-navbar-save-menu .dropdown-item:focus,
+.blockr-navbar-new-menu .dropdown-item:hover,
+.blockr-navbar-new-menu .dropdown-item:focus {
   background-color: #f3f4f6;
   color: #111827;
 }
 
-.blockr-navbar-save-menu .dropdown-item svg {
+.blockr-navbar-save-menu .dropdown-item svg,
+.blockr-navbar-new-menu .dropdown-item svg {
   width: 14px;
   height: 14px;
   color: #6b7280;
@@ -470,6 +475,28 @@
 .blockr-navbar-btn-new svg {
   width: 14px;
   height: 14px;
+}
+
+/* --- New Split Button --- */
+.blockr-navbar-new-group {
+  display: inline-flex;
+}
+
+.blockr-navbar-new-group > .blockr-navbar-btn-new:first-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.blockr-navbar-new-toggle {
+  gap: 0;
+  padding: 0 7px;
+  border-left: none;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.blockr-navbar-new-toggle::after {
+  margin: 0;
 }
 
 /* --- User Avatar --- */

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -477,6 +477,37 @@ test_that("New navigates to a fresh `?new=` id the loader honors (#68)", {
   expect_false(identical(fresh_id, "served"))
 })
 
+test_that("New split button offers a fresh `?new=` new tab (#74)", {
+  withr::local_options(
+    blockr.session_mgmt_backend = pins::board_temp(versioned = TRUE)
+  )
+
+  testServer(
+    manage_project_server,
+    {
+      doc <- xml2::read_html(
+        paste(as.character(output$new_controls), collapse = "")
+      )
+
+      in_place <- xml2::xml_find_all(
+        doc, ".//button[contains(@onclick, 'new_btn')]"
+      )
+      expect_length(in_place, 1L)
+
+      link <- xml2::xml_find_all(doc, ".//a[@target='_blank']")
+      expect_length(link, 1L)
+      expect_match(xml2::xml_text(link), "New in new tab")
+
+      href <- xml2::xml_attr(link, "href")
+      expect_match(href, "^\\?new=")
+      expect_identical(parseQueryString(href)[["mocksearch"]], "1")
+    },
+    args = list(
+      board = reactiveValues(board = new_board(), board_id = "served")
+    )
+  )
+})
+
 test_that("loader GET user-scopes via the configured user_pins_board (#70)", {
   visitor_backend <- pins::board_temp(versioned = TRUE)
 


### PR DESCRIPTION
## Summary

- "+ New" gains a caret dropdown (mirroring the Save split button) whose single item, "New in new tab", opens a fresh `?new=` board in a separate browser tab.
- Kept opt-in for the transition: the primary click still creates a board in place, so the default behaviour is unchanged. Flipping the primary action to new-tab (the issue's "99%" case) later is a one-line swap of which onclick the main button carries.
- The new-tab entry is a real `<a target="_blank">`, matching the existing "open in new tab" row links, so middle- and cmd/ctrl-click open a tab too. Its href reuses the same `build_query_string` + `drop_session_query` path as in-place New, so non-session query params survive.
- Styling reuses the Save split-button CSS via grouped selectors; the server-rendered control is covered by a unit test in `test-project.R`.

Fixes #74