### PR TITLE
Default the Save-as ID to the current id plus -copy

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -162,7 +162,10 @@ manage_project_server <- function(id, board, ...) {
         input$save_as_btn,
         {
           pending_save_mode("fork")
-          show_rack_id_modal(session, default = rand_names())
+          show_rack_id_modal(
+            session,
+            default = suggest_copy_id(current_rack_id(), backend)
+          )
         }
       )
 
@@ -1428,6 +1431,28 @@ show_rack_id_modal <- function(session, default) {
       )
     )
   )
+}
+
+suggest_copy_id <- function(base, backend, max_tries = 100L) {
+
+  taken <- function(id) {
+    isTRUE(
+      tryCatch(
+        rack_exists(rack_id_from_input(backend, list(id = id)), backend),
+        error = function(e) FALSE
+      )
+    )
+  }
+
+  candidate <- paste0(base, "-copy")
+
+  n <- 2L
+  while (taken(candidate) && n <= max_tries) {
+    candidate <- paste0(base, "-copy-", n)
+    n <- n + 1L
+  }
+
+  candidate
 }
 
 shiny_input_js <- function(ns_id, value) {

--- a/tests/testthat/test-menu.R
+++ b/tests/testthat/test-menu.R
@@ -284,3 +284,55 @@ test_that("modal_toggle updates the server-side selection", {
     )
   )
 })
+
+test_that("suggest_copy_id suffixes -copy when no copy exists (#99)", {
+
+  backend <- pins::board_temp(versioned = TRUE)
+  rack_create(backend, list(blocks = list()), id = "sales", name = "sales")
+
+  expect_identical(suggest_copy_id("sales", backend), "sales-copy")
+})
+
+test_that("suggest_copy_id increments past existing copies (#99)", {
+
+  backend <- pins::board_temp(versioned = TRUE)
+
+  for (nm in c("sales", "sales-copy", "sales-copy-2")) {
+    rack_create(backend, list(blocks = list()), id = nm, name = nm)
+  }
+
+  expect_identical(suggest_copy_id("sales", backend), "sales-copy-3")
+})
+
+test_that("suggest_copy_id falls back to the plain suffix at max_tries (#99)", {
+
+  backend <- pins::board_temp(versioned = TRUE)
+  rack_create(backend, list(blocks = list()), id = "x-copy", name = "x-copy")
+
+  expect_identical(suggest_copy_id("x", backend, max_tries = 1L), "x-copy")
+})
+
+test_that("save-as prefills the current id plus -copy as the default (#99)", {
+
+  withr::local_options(
+    blockr.session_mgmt_backend = pins::board_temp(versioned = TRUE)
+  )
+
+  captured <- NULL
+  local_mocked_bindings(
+    show_rack_id_modal = function(session, default) captured <<- default
+  )
+
+  testServer(
+    manage_project_server,
+    {
+      session$setInputs(save_as_btn = 1)
+      session$flushReact()
+
+      expect_identical(captured, "sales-copy")
+    },
+    args = list(
+      board = reactiveValues(board = new_board(), board_id = "sales")
+    )
+  )
+})


### PR DESCRIPTION
## Summary

- "Save as new workflow" seeded the ID field with a random `rand_names()` string, so forking a saved workflow always meant retyping a meaningful id.
- The field now defaults to `<current-id>-copy`, which is how people naturally name a variant of an existing workflow.
- On collision the suffix increments (`-copy-2`, `-copy-3`, …), so the suggested default is unique by construction and the user can just confirm without hitting the "already exists" error.
- The uniqueness probe reuses the same `rack_exists` check the confirm handler already enforces, so it matches the namespace a fork is actually created in (per-account on Connect).

Fixes #99