### PR TITLE
Resolve Connect pin owners from the bulk content listing

### DIFF
--- a/R/backend.R
+++ b/R/backend.R
@@ -16,8 +16,10 @@
 #'
 #' Set the `session_connect_tag` [blockr.core::blockr_option()] to an existing
 #' Connect tag's name (or a `"Category/Name"` path) to have the workflow listing
-#' filter server-side by that native tag; saves then apply it. Unset, the
-#' listing returns every pin and checks blockr membership only on load.
+#' filter server-side by that native tag; saves then apply it. A top-level tag
+#' is a category: naming one lists everything tagged beneath it, but saves
+#' cannot apply it, as Connect assigns only nested tags. Unset, the listing
+#' returns every pin and checks blockr membership only on load.
 #'
 #' @param session Shiny session whose request carries the Connect user session
 #'   token; defaults to the current reactive domain.

--- a/R/connect.R
+++ b/R/connect.R
@@ -84,19 +84,28 @@ rack_rename.rack_id_pins_connect <- function(id, backend, name, ...) {
 #' @export
 rack_list.pins_board_connect <- function(backend, tags = NULL, ...) {
 
-  tag_id <- connect_tag_id(backend)
+  spec <- connect_tag_spec()
 
-  if (not_null(tag_id)) {
-    return(connect_list_by_tag(backend, tag_id))
+  if (not_null(spec)) {
+    return(connect_list_by_tag(backend, spec))
   }
 
   connect_list_all_pins(backend)
 }
 
-connect_list_by_tag <- function(backend, tag_id) {
+# Search resolves the tag from the configured name or Category/Name path itself
+# and carries owners inline, so a tagged listing costs one paged request.
+# GET /tags/{id}/content instead needs the id resolved first and ignores
+# include=owner, leaving a GET /users call per owner. The quotes matter: an
+# unquoted space would end the filter value and start a search term, silently
+# matching nothing.
+connect_list_by_tag <- function(backend, spec) {
 
   items <- tryCatch(
-    connect_api(backend, "GET /tags/{tag_id}/content"),
+    connect_api_paged(
+      backend, "GET /search/content",
+      query = list(q = paste0("tag:\"", spec, "\""), include = "owner")
+    ),
     error = function(e) NULL
   )
 
@@ -168,8 +177,8 @@ connect_item_saved <- function(item) {
   connect_parse_time(stamp)
 }
 
-# `[[` rather than `$`: an item carrying only owner_guid (the tag listing, or a
-# Connect too old for include=owner) would partial-match that guid as `$owner`.
+# `[[` rather than `$`: an item carrying only owner_guid would partial-match
+# that guid as `$owner`.
 connect_item_owner <- function(backend, item) {
 
   name <- item[["owner"]][["username"]]
@@ -181,11 +190,11 @@ connect_item_owner <- function(backend, item) {
   connect_owner_cache$lookup(backend, item$owner_guid)
 }
 
-# The tag listing takes no `include`, so its items arrive with a guid and no
-# owner. A pin's owner is intrinsic to the content and identical for every
-# viewer, so the guid -> username resolution memoizes process-wide, keyed by
-# server and owner guid: an owner is resolved once however many of their pins
-# are listed.
+# Fallback for an item that arrives carrying a guid but no owner, the field
+# being nullable. A pin's owner is intrinsic to the content and identical for
+# every viewer, so the guid -> username resolution memoizes process-wide, keyed
+# by server and owner guid: an owner is resolved once however many of their
+# pins are listed.
 connect_owner_cache <- local({
 
   owners <- list()
@@ -224,11 +233,23 @@ connect_owner_name <- function(backend, guid) {
 
 # Connect native tags -------------------------------------------------------
 
-connect_tag_id <- function(backend) {
+connect_tag_spec <- function() {
 
   spec <- blockr_option("session_connect_tag", NULL)
 
   if (is.null(spec) || !is_string(spec) || !nzchar(spec)) {
+    return(NULL)
+  }
+
+  spec
+}
+
+# Applying a tag on upload needs its id, which only the tag listing carries.
+connect_tag_id <- function(backend) {
+
+  spec <- connect_tag_spec()
+
+  if (is.null(spec)) {
     return(NULL)
   }
 

--- a/R/connect.R
+++ b/R/connect.R
@@ -536,6 +536,13 @@ connect_api <- function(board, route, ..., body = NULL, query = NULL,
   )
 
   resp <- httr2::req_perform(req)
+
+  # A write endpoint may answer 200 with an empty text/plain body, which
+  # resp_body_json() rejects -- reporting a failure for a call that succeeded.
+  if (!httr2::resp_has_body(resp)) {
+    return(NULL)
+  }
+
   httr2::resp_body_json(resp)
 }
 

--- a/R/connect.R
+++ b/R/connect.R
@@ -106,11 +106,12 @@ connect_list_by_tag <- function(backend, tag_id) {
 # Without a configured tag the listing shows every pin and defers the blockr
 # membership check to load time. Whether an item is a pin is already in the
 # bulk response, so no pin is inspected -- a non-blockr pin is filtered out
-# only when someone tries to open it.
+# only when someone tries to open it. `include=owner` carries each owner's
+# username along, so the whole listing costs one request whatever the pin count.
 connect_list_all_pins <- function(backend) {
 
   items <- tryCatch(
-    connect_api(backend, "GET /content"),
+    connect_api(backend, "GET /content", query = list(include = "owner")),
     error = function(e) NULL
   )
 
@@ -130,7 +131,7 @@ connect_pin_records <- function(backend, items) {
     records[[length(records) + 1L]] <- new_rack_record(
       id = item$name,
       name = connect_item_title(item),
-      user = connect_owner_cache$lookup(backend, item$owner_guid),
+      user = connect_item_owner(backend, item),
       saved = connect_item_saved(item)
     )
   }
@@ -167,9 +168,24 @@ connect_item_saved <- function(item) {
   connect_parse_time(stamp)
 }
 
-# A pin's owner is intrinsic to the content and identical for every viewer, so
-# the guid -> username resolution memoizes process-wide, keyed by server and
-# owner guid: an owner is resolved once however many of their pins are listed.
+# `[[` rather than `$`: an item carrying only owner_guid (the tag listing, or a
+# Connect too old for include=owner) would partial-match that guid as `$owner`.
+connect_item_owner <- function(backend, item) {
+
+  name <- item[["owner"]][["username"]]
+
+  if (not_null(name) && nzchar(name)) {
+    return(name)
+  }
+
+  connect_owner_cache$lookup(backend, item$owner_guid)
+}
+
+# The tag listing takes no `include`, so its items arrive with a guid and no
+# owner. A pin's owner is intrinsic to the content and identical for every
+# viewer, so the guid -> username resolution memoizes process-wide, keyed by
+# server and owner guid: an owner is resolved once however many of their pins
+# are listed.
 connect_owner_cache <- local({
 
   owners <- list()

--- a/man/user_pins_board.Rd
+++ b/man/user_pins_board.Rd
@@ -34,8 +34,10 @@ application's own account.
 
 Set the \code{session_connect_tag} \code{\link[blockr.core:blockr_option]{blockr.core::blockr_option()}} to an existing
 Connect tag's name (or a \code{"Category/Name"} path) to have the workflow listing
-filter server-side by that native tag; saves then apply it. Unset, the
-listing returns every pin and checks blockr membership only on load.
+filter server-side by that native tag; saves then apply it. A top-level tag
+is a category: naming one lists everything tagged beneath it, but saves
+cannot apply it, as Connect assigns only nested tags. Unset, the listing
+returns every pin and checks blockr membership only on load.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/_fixtures/connect/content_include_owner.json
+++ b/tests/testthat/_fixtures/connect/content_include_owner.json
@@ -1,0 +1,240 @@
+{
+  "type": "list",
+  "attributes": {},
+  "value": [
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["guid", "name", "title", "description", "access_type", "locked", "locked_message", "connection_timeout", "read_timeout", "init_timeout", "idle_timeout", "max_processes", "min_processes", "max_conns_per_process", "load_factor", "memory_request", "memory_limit", "cpu_request", "cpu_limit", "amd_gpu_limit", "nvidia_gpu_limit", "service_account_name", "default_image_name", "default_environment_guid", "created_time", "last_deployed_time", "bundle_id", "app_mode", "content_category", "parameterized", "environment_guid", "cluster_name", "image_name", "r_version", "py_version", "quarto_version", "r_environment_management", "default_r_environment_management", "py_environment_management", "default_py_environment_management", "run_as", "run_as_current_user", "metrics_collection_enabled", "trace_collection_enabled", "owner_guid", "content_url", "dashboard_url", "app_role", "id", "owner", "public_content_status"]
+        }
+      },
+      "value": [
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["00000000-0000-4000-b000-000000000001"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["blockr-fixture-owner"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["blockr-fixture-owner"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": [""]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["acl"]
+        },
+        {
+          "type": "logical",
+          "attributes": {},
+          "value": [false]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": [""]
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["2020-01-01T00:00:00Z"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["2020-01-01T00:00:00Z"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["100"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["static"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["pin"]
+        },
+        {
+          "type": "logical",
+          "attributes": {},
+          "value": [false]
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "logical",
+          "attributes": {},
+          "value": [false]
+        },
+        {
+          "type": "NULL"
+        },
+        {
+          "type": "logical",
+          "attributes": {},
+          "value": [false]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["00000000-0000-4000-a000-000000000001"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["https://connect.example.com/content/00000000-0000-4000-b000-000000000001/"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["https://connect.example.com/connect/#/apps/00000000-0000-4000-b000-000000000001"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["owner"]
+        },
+        {
+          "type": "character",
+          "attributes": {},
+          "value": ["101"]
+        },
+        {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["guid", "username", "first_name", "last_name"]
+            }
+          },
+          "value": [
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["00000000-0000-4000-a000-000000000001"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["user_a"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["Alice"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["Test"]
+            }
+          ]
+        },
+        {
+          "type": "NULL"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/testthat/_fixtures/connect/search_content_tagged.json
+++ b/tests/testthat/_fixtures/connect/search_content_tagged.json
@@ -1,0 +1,262 @@
+{
+  "type": "list",
+  "attributes": {
+    "names": {
+      "type": "character",
+      "attributes": {},
+      "value": ["results", "current_page", "total"]
+    }
+  },
+  "value": [
+    {
+      "type": "list",
+      "attributes": {},
+      "value": [
+        {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["guid", "name", "title", "description", "access_type", "locked", "locked_message", "connection_timeout", "read_timeout", "init_timeout", "idle_timeout", "max_processes", "min_processes", "max_conns_per_process", "load_factor", "memory_request", "memory_limit", "cpu_request", "cpu_limit", "amd_gpu_limit", "nvidia_gpu_limit", "service_account_name", "default_image_name", "default_environment_guid", "created_time", "last_deployed_time", "bundle_id", "app_mode", "content_category", "parameterized", "environment_guid", "cluster_name", "image_name", "r_version", "py_version", "quarto_version", "r_environment_management", "default_r_environment_management", "py_environment_management", "default_py_environment_management", "run_as", "run_as_current_user", "metrics_collection_enabled", "trace_collection_enabled", "owner_guid", "content_url", "dashboard_url", "app_role", "id", "owner", "public_content_status"]
+            }
+          },
+          "value": [
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["00000000-0000-4000-b000-000000000001"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["blockr-fixture-tagged"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["blockr-fixture-tagged"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": [""]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["acl"]
+            },
+            {
+              "type": "logical",
+              "attributes": {},
+              "value": [false]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": [""]
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["2020-01-01T00:00:00Z"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["2020-01-01T00:00:00Z"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["100"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["static"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["pin"]
+            },
+            {
+              "type": "logical",
+              "attributes": {},
+              "value": [false]
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "logical",
+              "attributes": {},
+              "value": [false]
+            },
+            {
+              "type": "NULL"
+            },
+            {
+              "type": "logical",
+              "attributes": {},
+              "value": [false]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["00000000-0000-4000-a000-000000000001"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["https://connect.example.com/content/00000000-0000-4000-b000-000000000001/"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["https://connect.example.com/connect/#/apps/00000000-0000-4000-b000-000000000001"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["none"]
+            },
+            {
+              "type": "character",
+              "attributes": {},
+              "value": ["101"]
+            },
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["guid", "username", "first_name", "last_name"]
+                }
+              },
+              "value": [
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["00000000-0000-4000-a000-000000000001"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["user_a"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["Alice"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["Test"]
+                }
+              ]
+            },
+            {
+              "type": "NULL"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "integer",
+      "attributes": {},
+      "value": [1]
+    },
+    {
+      "type": "integer",
+      "attributes": {},
+      "value": [1]
+    }
+  ]
+}

--- a/tests/testthat/test-connect-tag.R
+++ b/tests/testthat/test-connect-tag.R
@@ -84,28 +84,40 @@ test_that("rack_list filters server-side by tag when configured", {
   board <- mock_board_connect()
   connect_owner_cache$reset()
   withr::defer(connect_owner_cache$reset())
-  withr::local_options(blockr.session_connect_tag = "blockr")
+  withr::local_options(blockr.session_connect_tag = "test/test2")
+
+  record_search <- function() {
+    rack_create(
+      board_a, blockr_test_session,
+      id = "blockr-fixture-tagged", name = "blockr-fixture-tagged"
+    )
+    content <- connect_content_find(board_a, "blockr-fixture-tagged")
+    tags <- connect_api(board_a, "GET /tags")
+    child <- Find(function(t) not_null(t$parent_id), tags)
+
+    connect_add_tag(board_a, content$guid, child$id)
+    connect_api(
+      board_a, "GET /search/content",
+      query = list(
+        q = "tag:\"test/test2\"", include = "owner",
+        page_number = 1L, page_size = 500L
+      )
+    )
+  }
+  envelope <- connect_fixture(
+    "search_content_tagged",
+    record_search,
+    pin_cleanup(board_a, "blockr-fixture-tagged")
+  )
 
   routes <- character()
+  queries <- list()
 
   local_mocked_bindings(
-    connect_api = function(board, route, ...) {
+    connect_api = function(board, route, ..., query = NULL) {
       routes[[length(routes) + 1L]] <<- route
-      if (identical(route, "GET /tags")) {
-        return(list(list(id = 5, name = "blockr", parent_id = NULL)))
-      }
-      if (grepl("GET /tags/", route, fixed = TRUE)) {
-        return(
-          list(
-            list(name = "wf-a", title = "WF A", content_category = "pin",
-                 owner_guid = "g", last_deployed_time = "2020-01-01T00:00:00Z")
-          )
-        )
-      }
-      if (grepl("GET /users", route, fixed = TRUE)) {
-        return(list(username = "user_a"))
-      }
-      list()
+      queries[[length(queries) + 1L]] <<- list(query)
+      envelope
     }
   )
   local_mocked_bindings(
@@ -116,10 +128,12 @@ test_that("rack_list filters server-side by tag when configured", {
 
   result <- rack_list(board)
 
+  expect_equal(routes, "GET /search/content")
+  expect_equal(queries[[1L]][[1L]]$q, "tag:\"test/test2\"")
+  expect_equal(queries[[1L]][[1L]]$include, "owner")
   expect_length(result, 1L)
-  expect_equal(result[[1L]]$id, "wf-a")
+  expect_equal(result[[1L]]$id, "blockr-fixture-tagged")
   expect_equal(result[[1L]]$user, "user_a")
-  expect_true(any(grepl("GET /tags/", routes, fixed = TRUE)))
 })
 
 # Tag on upload -------------------------------------------------------------

--- a/tests/testthat/test-connect-tag.R
+++ b/tests/testthat/test-connect-tag.R
@@ -206,6 +206,23 @@ test_that("rack_upload does not tag when no tag is configured", {
   expect_false(posted)
 })
 
+test_that("a tag write answering with an empty body is not a failure", {
+
+  board <- mock_board_connect(account = "user_a")
+  withr::local_options(blockr.session_connect_tag = "blockr")
+
+  local_mocked_bindings(
+    req_perform = function(req, ...) httr2::response(status_code = 200L),
+    .package = "httr2"
+  )
+  local_mocked_bindings(
+    connect_content_find = function(board, name) list(guid = "g"),
+    connect_resolve_tag = function(backend, spec) "9"
+  )
+
+  expect_no_warning(connect_apply_tag(board, "wf"))
+})
+
 test_that("a failed tag write does not fail the upload", {
 
   board <- mock_board_connect(account = "user_a")

--- a/tests/testthat/test-pins.R
+++ b/tests/testthat/test-pins.R
@@ -579,6 +579,40 @@ test_that("rack_list on Connect lists every pin without a per-pin probe", {
   expect_equal(result[[1L]]$saved, as.POSIXct("2020-02-01", tz = "UTC"))
 })
 
+test_that("rack_list on Connect resolves owners from the bulk listing", {
+
+  board <- mock_board_connect()
+  connect_owner_cache$reset()
+  withr::defer(connect_owner_cache$reset())
+
+  routes <- character()
+  includes <- character()
+
+  local_mocked_bindings(
+    connect_api = function(board, route, ..., query = NULL) {
+      routes[[length(routes) + 1L]] <<- route
+      includes[[length(includes) + 1L]] <<- coal(query$include, NA_character_)
+      list(
+        list(name = "wf-a", title = "WF A", content_category = "pin",
+             owner_guid = "guid-a", owner = list(username = "owner-a"),
+             last_deployed_time = "2020-03-01T00:00:00Z"),
+        list(name = "wf-b", title = "WF B", content_category = "pin",
+             owner_guid = "guid-b", owner = list(username = "owner-b"),
+             last_deployed_time = "2020-02-01T00:00:00Z"),
+        list(name = "wf-c", title = "WF C", content_category = "pin",
+             owner_guid = "guid-c", owner = list(username = "owner-c"),
+             last_deployed_time = "2020-01-01T00:00:00Z")
+      )
+    }
+  )
+
+  result <- rack_list(board)
+
+  expect_equal(routes, "GET /content")
+  expect_equal(includes, "owner")
+  expect_equal(chr_xtr(result, "user"), c("owner-a", "owner-b", "owner-c"))
+})
+
 test_that("rack_list on Connect skips non-pin content", {
 
   board <- mock_board_connect()

--- a/tests/testthat/test-pins.R
+++ b/tests/testthat/test-pins.R
@@ -585,6 +585,22 @@ test_that("rack_list on Connect resolves owners from the bulk listing", {
   connect_owner_cache$reset()
   withr::defer(connect_owner_cache$reset())
 
+  record_listing <- function() {
+    rack_create(
+      board_a, blockr_test_session,
+      id = "blockr-fixture-owner", name = "blockr-fixture-owner"
+    )
+    connect_api(
+      board_a, "GET /content",
+      query = list(name = "blockr-fixture-owner", include = "owner")
+    )
+  }
+  items <- connect_fixture(
+    "content_include_owner",
+    record_listing,
+    pin_cleanup(board_a, "blockr-fixture-owner")
+  )
+
   routes <- character()
   includes <- character()
 
@@ -592,25 +608,16 @@ test_that("rack_list on Connect resolves owners from the bulk listing", {
     connect_api = function(board, route, ..., query = NULL) {
       routes[[length(routes) + 1L]] <<- route
       includes[[length(includes) + 1L]] <<- coal(query$include, NA_character_)
-      list(
-        list(name = "wf-a", title = "WF A", content_category = "pin",
-             owner_guid = "guid-a", owner = list(username = "owner-a"),
-             last_deployed_time = "2020-03-01T00:00:00Z"),
-        list(name = "wf-b", title = "WF B", content_category = "pin",
-             owner_guid = "guid-b", owner = list(username = "owner-b"),
-             last_deployed_time = "2020-02-01T00:00:00Z"),
-        list(name = "wf-c", title = "WF C", content_category = "pin",
-             owner_guid = "guid-c", owner = list(username = "owner-c"),
-             last_deployed_time = "2020-01-01T00:00:00Z")
-      )
+      items
     }
   )
 
   result <- rack_list(board)
 
+  expect_equal(items[[1L]][["owner"]][["username"]], "user_a")
   expect_equal(routes, "GET /content")
   expect_equal(includes, "owner")
-  expect_equal(chr_xtr(result, "user"), c("owner-a", "owner-b", "owner-c"))
+  expect_equal(chr_xtr(result, "user"), "user_a")
 })
 
 test_that("rack_list on Connect skips non-pin content", {


### PR DESCRIPTION
## Summary

- The slow part of the Connect listing was never the bulk call — it was an N+1 hiding behind it. `connect_pin_records()` resolved every item's owner through `connect_owner_cache$lookup()`, i.e. a `GET /users/{guid}` per *distinct owner*. The memo is process-wide, so it only helps once an owner has been seen; a cold worker listing 150 pins spread over many owners pays one sequential round-trip per owner. Both listing paths had it.
- **Untagged path:** pass `include=owner` on the bulk `GET /content`. Connect populates an `owner` object (`guid`, `username`, `first_name`, `last_name`) per item, so the listing costs **exactly one request whatever the pin count**.
- **Tagged path:** move from `GET /tags/{id}/content` to `GET /search/content?q=tag:"<spec>"&include=owner`. The per-id endpoint takes no query parameters at all and *silently ignores* `include=owner`, so it could never carry owners inline. Search resolves the tag from the configured name or `Category/Name` path itself, so tag-id resolution drops out of the listing path entirely — `2 + one-per-owner` requests become **one**. It pages through the existing `connect_api_paged()`, whose 500-item pages happen to match the endpoint's cap exactly.
- No cache or index pin is needed for any of this. The overview is already centrally stored — Connect's content index *is* the overview, and one request reads it. What we were doing was re-reading the owner directory one guid at a time.
- **There is no 1000-pin limit here.** `GET /v1/content` has no pagination parameters at all — it takes exactly `name`, `owner_guid` and `include`. That cap was `pins::pin_search()`'s hardcoded `count = 1000`, on the tagged path #97 deleted as unreachable.

The last commit is a **separate bug fix** and can be dropped on its own if you would rather it went elsewhere. `POST /content/{guid}/tags` answers `200` with an **empty `text/plain` body**, and `connect_api()` parsed JSON unconditionally — so `connect_apply_tag()` raised `connect_tag_apply_failed` on **every** save with a tag configured, while the tag had in fact been applied. That made a real failure indistinguishable from success. Guarded with `httr2::resp_has_body()`.

## Verified against a live Connect

Measured on 2026.03.0 rather than reasoned from the spec:

- **One API round-trip costs ~159 ms.** That is what makes the arithmetic close: ~45–50 distinct owners lands on the reported 7–8 s, and 150 owners would be ~24 s. It also explains why the cost grows as the board does.
- `include=owner` populates `owner$username` on both `/content` and `/search/content`, and is free on the wire. Both listing tests assert against **recorded** fixtures rather than hand-written mocks, so they fail loudly if a Connect version stops honouring it.
- The `q=` filter language works as documented — `owner:`, `type:`, `tag:`, `is:`/`not:`, `-` negation. For `tag:` specifically: a parent category **rolls up to its children**, matching is **case-insensitive**, and quoting does **not** break the `Category/Name` separator. That last point is why the spec is quoted unconditionally: an unquoted space ends the filter value and turns the remainder into a search term, so a tag name containing one would silently match nothing (`owner:nic olas` returns 0).
- `connect_api_paged()` drives search unchanged: one request for the whole page, and forcing `page_size = 1` walks every page in order with no wasted trailing request.

The R side was never the problem: parsing a synthetic `/content` response and building records costs 0.23 s at 5000 content items and 1.1 s at 20000.

## Behaviour changes worth knowing

- **An unmatched tag now yields an empty listing.** Previously an unresolvable name made `connect_tag_id()` return `NULL`, which fell back to listing *every* pin — showing non-blockr pins because the tag was misconfigured is the worse failure.
- **Naming a category now works for listing.** A top-level Connect tag is a category, and `GET /tags/{category}/content` returns nothing, so configuring one used to give a silently empty menu; search rolls up to the tags beneath it. Saves still cannot apply a category — Connect rejects that with `Cannot assign a category to an app` — which the `user_pins_board` roxygen now states.
- **Bare tag names match that name anywhere in the hierarchy** (documented Connect behaviour), where `connect_resolve_tag()` picked one id and warned on ambiguity. A `Category/Name` path is exact either way.
- **Admin keys see all content** on `search/content`. Irrelevant for per-visitor viewer-scoped keys; it would matter for a deployment running on application credentials with an admin key.

I left `NEWS.md` and `Version` alone: there is no development section yet and opening one means a version bump, which is your call with the 0.1.0 CRAN submission still pending.

Fixes #102