### PR TITLE
Let the write gate workflow-id validity

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -175,32 +175,7 @@ manage_project_server <- function(id, board, ...) {
           new_id <- trimws(coal(input$rack_id_input, ""))
           mode <- pending_save_mode()
 
-          if (!valid_rack_id(new_id)) {
-            notify(
-              paste(
-                "Workflow ID may contain only letters, numbers, hyphens",
-                "and underscores."
-              ),
-              type = "error",
-              glue = FALSE,
-              session = session
-            )
-            return()
-          }
-
-          rid <- as_rack_id(list(id = new_id), backend)
-
-          record_exists <- isTRUE(
-            tryCatch(rack_exists(rid, backend), error = function(e) FALSE)
-          )
-
-          if (record_exists) {
-            notify(
-              sprintf("A workflow named %s already exists.", new_id),
-              type = "error",
-              glue = FALSE,
-              session = session
-            )
+          if (!nzchar(new_id)) {
             return()
           }
 
@@ -1423,7 +1398,7 @@ show_rack_id_modal <- function(session, default) {
       textInput(ns("rack_id_input"), "Workflow ID", value = default),
       tags$p(
         class = "blockr-rack-id-hint",
-        "Letters, numbers, hyphens and underscores. Must be unique."
+        "Must be unique."
       ),
       footer = tagList(
         modalButton("Cancel"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -147,10 +147,6 @@ reset_board_name <- function(board, name) {
   board
 }
 
-valid_rack_id <- function(x) {
-  is_string(x) && grepl("^[A-Za-z0-9_-]+$", x)
-}
-
 # the query keys rack_loader() interprets; everything else in the URL is
 # preserved across New and save/navigate so app-level params survive.
 session_query_keys <- c("id", "board_name", "user", "version", "new")

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -1140,6 +1140,12 @@ test_that("first save mints the chosen id, not the board id (#81)", {
   backend <- pins::board_temp(versioned = TRUE)
   withr::local_options(blockr.session_mgmt_backend = backend)
 
+  modal_closed <- FALSE
+  local_mocked_bindings(
+    removeModal = function(session) modal_closed <<- TRUE,
+    .package = "blockr.session"
+  )
+
   test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
 
   testServer(
@@ -1155,11 +1161,22 @@ test_that("first save mints the chosen id, not the board id (#81)", {
 
   expect_true("chosen-id" %in% pins::pin_list(backend))
   expect_false("auto-slug" %in% pins::pin_list(backend))
+  expect_true(modal_closed)
 })
 
-test_that("the id chooser rejects an invalid id (#81)", {
+test_that("a backend-rejected id keeps the id chooser open (#101)", {
   backend <- pins::board_temp(versioned = TRUE)
   withr::local_options(blockr.session_mgmt_backend = backend)
+
+  modal_closed <- FALSE
+  reported <- character()
+  local_mocked_bindings(
+    removeModal = function(session) modal_closed <<- TRUE,
+    notify = function(..., type = "message", glue = TRUE, session = NULL) {
+      reported <<- c(reported, paste0(...))
+    },
+    .package = "blockr.session"
+  )
 
   test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
 
@@ -1167,7 +1184,7 @@ test_that("the id chooser rejects an invalid id (#81)", {
     manage_project_server,
     {
       session$setInputs(save_btn = 1)
-      session$setInputs(rack_id_input = "no spaces!", rack_id_confirm = 1)
+      session$setInputs(rack_id_input = "no/slashes", rack_id_confirm = 1)
     },
     args = list(
       board = reactiveValues(board = test_board, board_id = "invalid-test")
@@ -1175,13 +1192,25 @@ test_that("the id chooser rejects an invalid id (#81)", {
   )
 
   expect_length(pins::pin_list(backend), 0L)
+  expect_false(modal_closed)
+  expect_match(paste(reported, collapse = " "), "must not contain slashes")
 })
 
-test_that("the id chooser refuses to overwrite an existing id (#81)", {
+test_that("a colliding id is caught by the write, not a pre-check (#101)", {
   backend <- pins::board_temp(versioned = TRUE)
   withr::local_options(blockr.session_mgmt_backend = backend)
 
   rack_create(backend, list(blocks = list()), id = "taken", name = "taken")
+
+  modal_closed <- FALSE
+  reported <- character()
+  local_mocked_bindings(
+    removeModal = function(session) modal_closed <<- TRUE,
+    notify = function(..., type = "message", glue = TRUE, session = NULL) {
+      reported <<- c(reported, paste0(...))
+    },
+    .package = "blockr.session"
+  )
 
   test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
 
@@ -1198,4 +1227,40 @@ test_that("the id chooser refuses to overwrite an existing id (#81)", {
 
   expect_equal(pins::pin_list(backend), "taken")
   expect_equal(nrow(pins::pin_versions(backend, "taken")), 1L)
+  expect_false(modal_closed)
+  expect_match(
+    paste(reported, collapse = " "),
+    "already exists; use rack_append"
+  )
+})
+
+test_that("a blank id attempts no write (#101)", {
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  attempted <- FALSE
+  local_mocked_bindings(
+    rack_create = function(...) {
+      attempted <<- TRUE
+      NULL
+    },
+    .package = "blockr.session"
+  )
+
+  test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  testServer(
+    manage_project_server,
+    {
+      session$setInputs(save_btn = 1)
+      session$setInputs(rack_id_input = "   ", rack_id_confirm = 1)
+      session$setInputs(rack_id_input = "", rack_id_confirm = 2)
+    },
+    args = list(
+      board = reactiveValues(board = test_board, board_id = "blank-test")
+    )
+  )
+
+  expect_false(attempted)
+  expect_length(pins::pin_list(backend), 0L)
 })


### PR DESCRIPTION
## Summary

- The id chooser pre-validated a typed workflow id twice before saving — `valid_rack_id()` for the character set, `rack_exists()` for uniqueness — and neither check could be authoritative. Uniqueness is racy: another tab or another Connect user can mint the id between the check and `rack_create()`, which has to handle the collision regardless. Charset is backend-specific: the single regex `^[A-Za-z0-9_-]+$` was at once too strict for a file board (`pins:::check_pin_name` forbids only slashes) and too loose for Connect.
- Both pre-checks are gone, so the write is the only gate. The `rack_create()` call still runs inside `tryCatch()`, `removeModal()` still fires only on success, and a failure now leaves the modal open with the backend's own error surfaced.
- One local guard stays, the universal non-backend one: a blank or whitespace-only field attempts no write.
- Dropped `valid_rack_id()` along with its only caller. The `rack_exists()` generic stays — `suggest_copy_id()` reads it to pick a free default, and `rack_create()` uses it internally.
- The modal hint no longer advertises a character set the app cannot promise.

Both entry points funnel through this handler, so the change covers the `save` create path and the `save as` fork path alike.

Fixes #101
