### PR TITLE
Report a failed save probe instead of routing to the chooser

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -103,9 +103,14 @@ manage_project_server <- function(id, board, ...) {
             as_rack_id(list(id = board$board_id), backend)
           )
 
-          exists <- isTRUE(
-            tryCatch(rack_exists(target, backend), error = function(e) FALSE)
+          exists <- tryCatch(
+            rack_exists(target, backend),
+            error = cnd_to_notif(type = "error")
           )
+
+          if (is.null(exists)) {
+            return()
+          }
 
           if (!exists) {
             pending_save_mode("create")

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -1234,6 +1234,40 @@ test_that("a colliding id is caught by the write, not a pre-check (#101)", {
   )
 })
 
+test_that("a failed existence probe reports and opens no chooser (#112)", {
+  backend <- pins::board_temp(versioned = TRUE)
+  withr::local_options(blockr.session_mgmt_backend = backend)
+
+  rack_create(backend, list(blocks = list()), id = "probe-test", name = "Probe")
+
+  chooser_opened <- FALSE
+  reported <- character()
+  local_mocked_bindings(
+    rack_exists = function(id, backend, ...) {
+      stop("Connect is unreachable")
+    },
+    show_rack_id_modal = function(...) chooser_opened <<- TRUE,
+    notify = function(..., type = "message", glue = TRUE, session = NULL) {
+      reported <<- c(reported, paste0(...))
+    },
+    .package = "blockr.session"
+  )
+
+  test_board <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  testServer(
+    manage_project_server,
+    session$setInputs(save_btn = 1),
+    args = list(
+      board = reactiveValues(board = test_board, board_id = "probe-test")
+    )
+  )
+
+  expect_false(chooser_opened)
+  expect_match(paste(reported, collapse = " "), "Connect is unreachable")
+  expect_equal(nrow(pins::pin_versions(backend, "probe-test")), 1L)
+})
+
 test_that("a blank id attempts no write (#101)", {
   backend <- pins::board_temp(versioned = TRUE)
   withr::local_options(blockr.session_mgmt_backend = backend)


### PR DESCRIPTION
## Summary

- The save handler collapsed a failed `rack_exists()` probe into "record absent" via `error = function(e) FALSE`. The pins layer already answers `FALSE` cleanly for a missing pin — `pin_exists.pins_board_connect()` (pins 1.4.2) catches `pins_pin_missing` itself and lets everything else through — so that handler only ever ate backend failures: an expired visitor token, a 502, Connect unreachable.
- Each of those was then reported as "this board has never been saved" and routed into the id chooser, which can only create: both `pending_save_mode()` values call `rack_create()`, so confirming aborted with `rack_create_exists` for a board the user owns and had saved before, and saving stayed blocked until reload.
- A probe error now surfaces through the same `cnd_to_notif()` path the writes already use, and the chooser opens only on a definite `FALSE`. Same shape as the fix in #111: the write is the gate, and a pre-check that could not ask is not an answer.
- The regression test drives `save_btn` against an already-saved record with `rack_exists` mocked to throw, asserting the chooser stays shut, the backend error reaches the user, and no version is appended. Confirmed failing on the unfixed handler — the chooser opened and nothing was reported.

Fixes #112
