### PR TITLE
Return no version when the post-write lookup fails

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -9,7 +9,7 @@ new_rack_id_pins_connect <- function(user, id, version = NULL) {
     )
   }
 
-  if (not_null(version) && (!is_string(version) || !nzchar(version))) {
+  if (not_null(version) && !is_version_string(version)) {
     blockr_abort(
       "rack_id_pins_connect version must be a non-empty string.",
       class = "rack_id_pins_connect_invalid_version"
@@ -403,7 +403,7 @@ rack_upload.pins_board_connect <- function(backend, path, id, name = NULL,
   new_rack_id_pins_connect(
     user = backend$account,
     id = slug,
-    version = rack_info(base, backend)$version[1L]
+    version = latest_version(base, backend)
   )
 }
 

--- a/R/connect.R
+++ b/R/connect.R
@@ -9,7 +9,7 @@ new_rack_id_pins_connect <- function(user, id, version = NULL) {
     )
   }
 
-  if (not_null(version) && !is_version_string(version)) {
+  if (not_null(version) && (!is_string(version) || !nzchar(version))) {
     blockr_abort(
       "rack_id_pins_connect version must be a non-empty string.",
       class = "rack_id_pins_connect_invalid_version"

--- a/R/pins.R
+++ b/R/pins.R
@@ -2,7 +2,7 @@
 
 new_rack_id_pins <- function(id, version = NULL) {
 
-  if (not_null(version) && !is_version_string(version)) {
+  if (not_null(version) && (!is_string(version) || !nzchar(version))) {
     blockr_abort(
       "rack_id_pins version must be a non-empty string.",
       class = "rack_id_pins_invalid_version"
@@ -10,10 +10,6 @@ new_rack_id_pins <- function(id, version = NULL) {
   }
 
   new_rack_id(id, version = version, class = "rack_id_pins")
-}
-
-is_version_string <- function(x) {
-  is_string(x) && !is.na(x) && nzchar(x)
 }
 
 #' @export

--- a/R/pins.R
+++ b/R/pins.R
@@ -2,7 +2,7 @@
 
 new_rack_id_pins <- function(id, version = NULL) {
 
-  if (not_null(version) && (!is_string(version) || !nzchar(version))) {
+  if (not_null(version) && !is_version_string(version)) {
     blockr_abort(
       "rack_id_pins version must be a non-empty string.",
       class = "rack_id_pins_invalid_version"
@@ -10,6 +10,10 @@ new_rack_id_pins <- function(id, version = NULL) {
   }
 
   new_rack_id(id, version = version, class = "rack_id_pins")
+}
+
+is_version_string <- function(x) {
+  is_string(x) && !is.na(x) && nzchar(x)
 }
 
 #' @export
@@ -112,7 +116,7 @@ rack_rename.rack_id_pins <- function(id, backend, name, ...) {
     tags = unique(c(meta$tags, blockr_session_tags()))
   )
 
-  new_rack_id_pins(id$id, version = rack_info(id, backend)$version[1L])
+  new_rack_id_pins(id$id, version = latest_version(id, backend))
 }
 
 # rack_exists ---------------------------------------------------------------
@@ -307,6 +311,17 @@ rack_info.rack_id_pins <- function(id, backend, ...) {
   )
 }
 
+latest_version <- function(id, backend) {
+
+  info <- rack_info(id, backend)
+
+  if (nrow(info) == 0L) {
+    return(NULL)
+  }
+
+  info$version[1L]
+}
+
 # rack_download -------------------------------------------------------------
 
 #' @export
@@ -381,7 +396,7 @@ rack_upload.pins_board <- function(backend, path, id, name = NULL,
     tags = blockr_session_tags()
   )
 
-  new_rack_id_pins(id$id, version = rack_info(id, backend)$version[1L])
+  new_rack_id_pins(id$id, version = latest_version(id, backend))
 }
 
 # rack_delete ---------------------------------------------------------------

--- a/R/rack.R
+++ b/R/rack.R
@@ -108,6 +108,13 @@ new_rack_id <- function(id, version = NULL, user = NULL, ...,
     )
   }
 
+  if (anyNA(version)) {
+    blockr_abort(
+      "rack id version must not be NA.",
+      class = "rack_id_invalid_version"
+    )
+  }
+
   structure(
     list(id = id, version = version, user = user, ...),
     class = c(class, "rack_id")

--- a/tests/testthat/test-pins.R
+++ b/tests/testthat/test-pins.R
@@ -23,7 +23,7 @@ test_that("new_rack_id_pins rejects empty version", {
 test_that("new_rack_id_pins rejects an NA version", {
   expect_error(
     new_rack_id_pins("my_board", NA_character_),
-    class = "rack_id_pins_invalid_version"
+    class = "rack_id_invalid_version"
   )
 })
 
@@ -54,7 +54,7 @@ test_that("new_rack_id_pins_connect rejects empty user", {
 test_that("new_rack_id_pins_connect rejects an NA version", {
   expect_error(
     new_rack_id_pins_connect("alice", "my_board", NA_character_),
-    class = "rack_id_pins_connect_invalid_version"
+    class = "rack_id_invalid_version"
   )
 })
 

--- a/tests/testthat/test-pins.R
+++ b/tests/testthat/test-pins.R
@@ -20,6 +20,13 @@ test_that("new_rack_id_pins rejects empty version", {
   )
 })
 
+test_that("new_rack_id_pins rejects an NA version", {
+  expect_error(
+    new_rack_id_pins("my_board", NA_character_),
+    class = "rack_id_pins_invalid_version"
+  )
+})
+
 test_that("new_rack_id_pins_connect basic construction", {
 
   id <- new_rack_id_pins_connect("alice", "my_board")
@@ -41,6 +48,13 @@ test_that("new_rack_id_pins_connect rejects empty user", {
   expect_error(
     new_rack_id_pins_connect("", "my_board"),
     class = "rack_id_pins_connect_invalid_user"
+  )
+})
+
+test_that("new_rack_id_pins_connect rejects an NA version", {
+  expect_error(
+    new_rack_id_pins_connect("alice", "my_board", NA_character_),
+    class = "rack_id_pins_connect_invalid_version"
   )
 })
 
@@ -212,6 +226,42 @@ test_that("rack_append adds a version and preserves the name", {
   expect_equal(rack_name(new_rack_id_pins("board-x"), backend), "Original")
 })
 
+test_that("rack_append reports no version when the lookup fails after upload", {
+
+  backend <- pins::board_temp(versioned = TRUE)
+
+  rack_create(backend, list(blocks = list(a = 1)), id = "wf", name = "WF")
+
+  # The pin_upload call consults pin_versions itself to prune, so the failure
+  # has to be armed by the write rather than mocked in up front.
+  uploaded <- FALSE
+  real_upload <- pins::pin_upload
+  real_versions <- pins::pin_versions
+
+  local_mocked_bindings(
+    pin_upload = function(...) {
+      out <- real_upload(...)
+      uploaded <<- TRUE
+      out
+    },
+    pin_versions = function(...) {
+      if (uploaded) {
+        stop("Posit Connect API failed [502]")
+      }
+      real_versions(...)
+    },
+    .package = "pins"
+  )
+
+  Sys.sleep(1.1)
+  res <- suppressWarnings(
+    rack_append(new_rack_id_pins("wf"), backend, list(blocks = list(a = 2)))
+  )
+
+  expect_null(res$version)
+  expect_equal(board_query_string(res, backend), "?id=wf")
+})
+
 test_that("rack_append errors when the record does not exist", {
 
   # rack_append only appends; creating a missing record is rack_create's job.
@@ -371,6 +421,39 @@ test_that("rack_rename writes the name without changing identity", {
   expect_equal(res$id, "stable-id")
   expect_equal(pins::pin_list(backend), "stable-id")
   expect_equal(rack_name(new_rack_id_pins("stable-id"), backend), "After")
+})
+
+test_that("rack_rename reports no version when the lookup fails after upload", {
+
+  backend <- pins::board_temp(versioned = TRUE)
+
+  rack_create(backend, list(blocks = list()), id = "stable-id", name = "Before")
+
+  uploaded <- FALSE
+  real_upload <- pins::pin_upload
+  real_versions <- pins::pin_versions
+
+  local_mocked_bindings(
+    pin_upload = function(...) {
+      out <- real_upload(...)
+      uploaded <<- TRUE
+      out
+    },
+    pin_versions = function(...) {
+      if (uploaded) {
+        stop("Posit Connect API failed [502]")
+      }
+      real_versions(...)
+    },
+    .package = "pins"
+  )
+
+  Sys.sleep(1.1)
+  res <- suppressWarnings(
+    rack_rename(new_rack_id_pins("stable-id"), backend, "After")
+  )
+
+  expect_null(res$version)
 })
 
 test_that("rack_rename errors when the record has no versions", {
@@ -1094,6 +1177,30 @@ test_that("rack_create on Connect uploads to the owner-qualified slug", {
   expect_equal(result$id, "my_new_board")
   expect_equal(result$version, versions$version[1L])
   expect_equal(uploaded_name, "user_a/my_new_board")
+})
+
+test_that("rack_create on Connect reports no version when the lookup fails", {
+
+  board <- mock_board_connect(account = "user_a")
+
+  local_mocked_bindings(
+    pin_upload = function(...) invisible(),
+    pin_exists = function(...) FALSE,
+    pin_versions = function(...) stop("Posit Connect API failed [502]"),
+    .package = "pins"
+  )
+  local_mocked_bindings(
+    connect_content_find = function(board, name) list(guid = "g"),
+    connect_api = function(...) list()
+  )
+
+  res <- suppressWarnings(
+    rack_create(board, blockr_test_session, id = "my_new_board",
+                name = "my_new_board")
+  )
+
+  expect_null(res$version)
+  expect_equal(board_query_string(res, board), "?id=my_new_board")
 })
 
 test_that("rack_create on Connect sets the content title to the name", {

--- a/tests/testthat/test-rack.R
+++ b/tests/testthat/test-rack.R
@@ -14,6 +14,21 @@ test_that("new_rack_id rejects non-string", {
   )
 })
 
+test_that("new_rack_id rejects an NA version whatever its type", {
+
+  expect_error(
+    new_rack_id("board", version = NA_character_),
+    class = "rack_id_invalid_version"
+  )
+
+  # A backend numbering versions off a counter carries integers, so the guard
+  # cannot key on the string spelling of an unresolved version.
+  expect_error(
+    new_rack_id("board", version = NA_integer_),
+    class = "rack_id_invalid_version"
+  )
+})
+
 test_that("new_rack_id stores id, version and user", {
   id <- new_rack_id("board", version = "v1", user = "alice")
   expect_equal(id$id, "board")


### PR DESCRIPTION
## Summary

- The version lookup that follows a write degrades a failed `pin_versions()` to `NULL`, and `rack_info()` turns that into a zero-row frame — but `$version[1L]` on a zero-row column is `NA_character_`, not empty. Three post-write sites indexed it that way, so `rack_upload()` (both backends) and `rack_rename()` could hand back a `rack_id` naming a version that was never created.
- Nothing downstream rejected it: `is_string(NA_character_)`, `nzchar(NA_character_)` and `not_null(NA_character_)` are all `TRUE`, so the constructors' non-empty-string guard and the `board_query_string()` gate both passed it through.
- The `latest_version()` helper reports an empty lookup as absent, and the three post-write sites now go through it. An id carrying no version already means "latest" everywhere else, which is the right reading when the write succeeded and only the version is unknown.
- The `new_rack_id()` constructor rejects an `NA` version outright, so the invariant holds for every backend rather than only the pins pair. The check is `anyNA()` rather than a string test on purpose: a backend numbering versions off a counter — as `vignettes/custom-storage-backend.qmd` does — carries an integer, and its unresolved version is `NA_integer_`. The pins constructors keep their pre-existing non-empty-string requirement.

Guarding this per backend would have meant rediscovering the same hole in each one, since the zero-row lookup that produces the `NA` is a shape any implementation can hit.

One correction to the issue: the `version=NA` URL is not reachable through the Save observers, because both rebuild the id with `as_rack_id(list(id = res$id, user = res$user), backend)` (`R/server.R:151` and `R/server.R:203`), which drops the version. Driving the real upload path with the post-write lookup forced to fail, `rack_append()` did return a version of `NA` and `board_query_string()` on that id gave `?id=wf&version=NA` — but the id the observer actually puts in the address bar gave `?id=wf`. The defect is the malformed `rack_id` handed back by the exported generics, not the URL.

Forcing the failure needs the write to arm it rather than a mock set up in advance: `pin_upload()` consults `pin_versions()` itself to prune, so failing that binding up front breaks the upload instead of the lookup after it.

Fixes #113
